### PR TITLE
Add Dixit bonus rule for match and delta bets

### DIFF
--- a/Calculator/DixitBonusCalculator.cs
+++ b/Calculator/DixitBonusCalculator.cs
@@ -1,0 +1,75 @@
+namespace TipTournament2._0.Calculator
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using TipTournament2._0.Models;
+
+    public static class DixitBonusCalculator
+    {
+        public static void ApplyDixitBonus(List<MatchBet> bets)
+        {
+            if (bets == null || bets.Count == 0)
+            {
+                return;
+            }
+
+            var totalCount = bets.Count;
+            var correctCount = bets.Count(b => b.Result != BetResult.NOTHING);
+
+            foreach (var bet in bets)
+            {
+                if (bet.Result == BetResult.NOTHING)
+                {
+                    bet.DixitBonus = 0;
+                    continue;
+                }
+
+                bet.DixitBonus = CalculateBonus(correctCount, totalCount);
+            }
+        }
+
+        public static void ApplyDixitBonus(List<DeltaBet> bets)
+        {
+            if (bets == null || bets.Count == 0)
+            {
+                return;
+            }
+
+            var totalCount = bets.Count;
+            var correctCount = bets.Count(b => b.Result != null && b.Result.Points > 0);
+
+            foreach (var bet in bets)
+            {
+                if (bet.Result == null || bet.Result.Points <= 0)
+                {
+                    bet.DixitBonus = 0;
+                    continue;
+                }
+
+                bet.DixitBonus = CalculateBonus(correctCount, totalCount);
+            }
+        }
+
+        private static int CalculateBonus(int correctCount, int totalCount)
+        {
+            if (correctCount == 1)
+            {
+                return 3;
+            }
+
+            var ratio = (double)correctCount / totalCount;
+
+            if (ratio < 0.20)
+            {
+                return 2;
+            }
+
+            if (ratio < 0.40)
+            {
+                return 1;
+            }
+
+            return 0;
+        }
+    }
+}

--- a/ClientApp/src/components/MainPage/UserBetRow.tsx
+++ b/ClientApp/src/components/MainPage/UserBetRow.tsx
@@ -24,7 +24,10 @@ export class UserBetRow extends React.Component<UserBetRowProps> {
         return (
             <>
                 <td className={classNames.textClass}>{bet.tip.homeTeam} : {bet.tip.awayTeam}</td>
-                <td className={classNames.bgClass}>{bet.result}</td>
+                <td className={classNames.bgClass}>
+                    {bet.result}
+                    {bet.dixitBonus > 0 && <span className="dixit-bonus">+{bet.dixitBonus}</span>}
+                </td>
             </>
         );
     }

--- a/ClientApp/src/components/RulePage.tsx
+++ b/ClientApp/src/components/RulePage.tsx
@@ -130,6 +130,26 @@ export class RulePage extends React.Component<RulePageProps> {
                                 <span>Špatný tip</span>
                             </div>
                         </div>
+                        <div className="rules-note">
+                            <strong>Dixit bonus:</strong> Pokud správně tipneš výsledek zápasu a většina hráčů se mýlí, získáváš bonusové body:
+                        </div>
+                        <div className="rules-scoring">
+                            <div className="rules-score-row">
+                                <span className="rules-points rules-points-1">+1 b.</span>
+                                <span>Méně než 40 % hráčů tiplo správně</span>
+                            </div>
+                            <div className="rules-score-row">
+                                <span className="rules-points rules-points-2">+2 b.</span>
+                                <span>Méně než 20 % hráčů tiplo správně</span>
+                            </div>
+                            <div className="rules-score-row">
+                                <span className="rules-points rules-points-3">+3 b.</span>
+                                <span>Jako jediný jsi tipnul správně</span>
+                            </div>
+                        </div>
+                        <div className="rules-note">
+                            Bonusy se nesčítají — platí vždy nejvyšší dosažený stupeň. Bonus se počítá ze všech hráčů, kteří na daný zápas tipovali.
+                        </div>
                     </div>
 
                     <div className="rules-card">

--- a/ClientApp/src/custom.css
+++ b/ClientApp/src/custom.css
@@ -193,6 +193,13 @@ code {
     margin-top: 1rem;
 }
 
+.dixit-bonus {
+    color: #d4a017;
+    font-size: 0.75rem;
+    font-weight: 700;
+    margin-left: 0.25rem;
+}
+
 /* ===== Rules Page ===== */
 
 .rules-page {

--- a/ClientApp/src/typings/index.ts
+++ b/ClientApp/src/typings/index.ts
@@ -40,6 +40,7 @@ export interface Bet {
     match: Match;
     tip: Result;
     result: BetResult;
+    dixitBonus: number;
     user: User;
 }
 
@@ -58,6 +59,7 @@ export interface DeltaBet {
     homeTeamBet: Team;
     awayTeamBet: Team;
     result: DeltaBetResult;
+    dixitBonus: number;
     user: User;
 }
 

--- a/Coordinator/DeltaResultCoordinator.cs
+++ b/Coordinator/DeltaResultCoordinator.cs
@@ -49,8 +49,9 @@
         private void UpdateDeltaBetsResults(Match match)
         {
             var bets = this.dbContextWrapper.GetDeltaBetsByMatchId(match.Id);
-            var updateBets = this.betResultMaker.UpdateDeltaBetsResult(bets, match);
-            this.dbContextWrapper.UpdateDeltaBets(updateBets);
+            var updatedBets = this.betResultMaker.UpdateDeltaBetsResult(bets, match);
+            DixitBonusCalculator.ApplyDixitBonus(updatedBets);
+            this.dbContextWrapper.UpdateDeltaBets(updatedBets);
         }
 
         private void RecalculatePoints(string matchId)
@@ -61,8 +62,8 @@
                 var betForUser = this.dbContextWrapper.GetDeltaBetByMatchId(user.Id, matchId);
                 if(betForUser != null)
                 {
-                    user.DeltaPoints += betForUser.Result.Points;
-                    user.TotalPoints += betForUser.Result.Points;
+                    user.DeltaPoints += betForUser.Result.Points + betForUser.DixitBonus;
+                    user.TotalPoints += betForUser.Result.Points + betForUser.DixitBonus;
                 }
             }
 

--- a/Coordinator/GroupMatchesResultCoordinator.cs
+++ b/Coordinator/GroupMatchesResultCoordinator.cs
@@ -36,8 +36,9 @@
         private void UpdateBetsResult(Match match)
         {
             var bets = this.dbContextWrapper.GetBetsForMatch(match);
-            var updateBets = this.betResultMaker.UpdateBetResult(bets, match.Result);
-            this.dbContextWrapper.UpdateBets(updateBets);
+            var updatedBets = this.betResultMaker.UpdateBetResult(bets, match.Result);
+            DixitBonusCalculator.ApplyDixitBonus(updatedBets);
+            this.dbContextWrapper.UpdateBets(updatedBets);
         }
 
         private void RecalculatePoints(Match match)
@@ -48,8 +49,8 @@
                 var betForUser = this.dbContextWrapper.GetBetForMatchAndUser(match, user.Id);
                 if (betForUser != null)
                 {
-                    user.AlfaPoints += (int)betForUser.Result;
-                    user.TotalPoints += (int)betForUser.Result;
+                    user.AlfaPoints += (int)betForUser.Result + betForUser.DixitBonus;
+                    user.TotalPoints += (int)betForUser.Result + betForUser.DixitBonus;
                 }
             }
 

--- a/Data/Migrations/20260409195446_AddDixitBonusToMatchBet.Designer.cs
+++ b/Data/Migrations/20260409195446_AddDixitBonusToMatchBet.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TipTournament2._0.Data;
 
 namespace TipTournament2._0.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260409195446_AddDixitBonusToMatchBet")]
+    partial class AddDixitBonusToMatchBet
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -390,9 +392,6 @@ namespace TipTournament2._0.Data.Migrations
 
                     b.Property<string>("AwayTeamBetId")
                         .HasColumnType("nvarchar(450)");
-
-                    b.Property<int>("DixitBonus")
-                        .HasColumnType("int");
 
                     b.Property<string>("HomeTeamBetId")
                         .HasColumnType("nvarchar(450)");

--- a/Data/Migrations/20260409195446_AddDixitBonusToMatchBet.cs
+++ b/Data/Migrations/20260409195446_AddDixitBonusToMatchBet.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace TipTournament2._0.Data.Migrations
+{
+    public partial class AddDixitBonusToMatchBet : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "DixitBonus",
+                table: "Bets",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DixitBonus",
+                table: "Bets");
+        }
+    }
+}

--- a/Data/Migrations/20260409202441_AddDixitBonusToDeltaBet.Designer.cs
+++ b/Data/Migrations/20260409202441_AddDixitBonusToDeltaBet.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TipTournament2._0.Data;
 
 namespace TipTournament2._0.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260409202441_AddDixitBonusToDeltaBet")]
+    partial class AddDixitBonusToDeltaBet
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Data/Migrations/20260409202441_AddDixitBonusToDeltaBet.cs
+++ b/Data/Migrations/20260409202441_AddDixitBonusToDeltaBet.cs
@@ -1,0 +1,23 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace TipTournament2._0.Data.Migrations
+{
+    public partial class AddDixitBonusToDeltaBet : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "DixitBonus",
+                table: "DeltaBets",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DixitBonus",
+                table: "DeltaBets");
+        }
+    }
+}

--- a/Models/DeltaBet.cs
+++ b/Models/DeltaBet.cs
@@ -37,5 +37,7 @@
 
         [ForeignKey("UserId")]
         public ApplicationUser User { get; set; }
+
+        public int DixitBonus { get; set; }
     }
 }

--- a/Models/MatchBet.cs
+++ b/Models/MatchBet.cs
@@ -23,5 +23,7 @@
         public Result Tip { get; set; }
 
         public BetResult Result { get; set; }
+
+        public int DixitBonus { get; set; }
     }
 }

--- a/TipTournament2.0.Tests/Calculator/DixitBonusCalculatorTests.cs
+++ b/TipTournament2.0.Tests/Calculator/DixitBonusCalculatorTests.cs
@@ -1,0 +1,175 @@
+namespace TipTournament2._0.Tests.Calculator
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using TipTournament2._0.Calculator;
+    using TipTournament2._0.Models;
+    using Xunit;
+
+    public class DixitBonusCalculatorTests
+    {
+        [Fact]
+        public void ApplyDixitBonus_NoBets_DoesNotThrow()
+        {
+            DixitBonusCalculator.ApplyDixitBonus(new List<MatchBet>());
+            DixitBonusCalculator.ApplyDixitBonus((List<MatchBet>)null);
+        }
+
+        [Fact]
+        public void ApplyDixitBonus_AllWrong_AllBonusZero()
+        {
+            var bets = Enumerable.Range(0, 5)
+                .Select(_ => new MatchBet { Result = BetResult.NOTHING })
+                .ToList();
+
+            DixitBonusCalculator.ApplyDixitBonus(bets);
+
+            Assert.All(bets, b => Assert.Equal(0, b.DixitBonus));
+        }
+
+        [Fact]
+        public void ApplyDixitBonus_50PercentCorrect_NoBonus()
+        {
+            var bets = new List<MatchBet>
+            {
+                new MatchBet { Result = BetResult.WINNER },
+                new MatchBet { Result = BetResult.WINNER },
+                new MatchBet { Result = BetResult.WINNER },
+                new MatchBet { Result = BetResult.WINNER },
+                new MatchBet { Result = BetResult.WINNER },
+                new MatchBet { Result = BetResult.NOTHING },
+                new MatchBet { Result = BetResult.NOTHING },
+                new MatchBet { Result = BetResult.NOTHING },
+                new MatchBet { Result = BetResult.NOTHING },
+                new MatchBet { Result = BetResult.NOTHING },
+            };
+
+            DixitBonusCalculator.ApplyDixitBonus(bets);
+
+            Assert.All(bets, b => Assert.Equal(0, b.DixitBonus));
+        }
+
+        [Fact]
+        public void ApplyDixitBonus_39PercentCorrect_Plus1()
+        {
+            // 39 out of 100 = 39%
+            var bets = new List<MatchBet>();
+            for (int i = 0; i < 39; i++)
+                bets.Add(new MatchBet { Result = BetResult.WINNER });
+            for (int i = 0; i < 61; i++)
+                bets.Add(new MatchBet { Result = BetResult.NOTHING });
+
+            DixitBonusCalculator.ApplyDixitBonus(bets);
+
+            Assert.All(bets.Where(b => b.Result != BetResult.NOTHING), b => Assert.Equal(1, b.DixitBonus));
+            Assert.All(bets.Where(b => b.Result == BetResult.NOTHING), b => Assert.Equal(0, b.DixitBonus));
+        }
+
+        [Fact]
+        public void ApplyDixitBonus_19PercentCorrect_Plus2()
+        {
+            // 19 out of 100 = 19%
+            var bets = new List<MatchBet>();
+            for (int i = 0; i < 19; i++)
+                bets.Add(new MatchBet { Result = BetResult.SCORE });
+            for (int i = 0; i < 81; i++)
+                bets.Add(new MatchBet { Result = BetResult.NOTHING });
+
+            DixitBonusCalculator.ApplyDixitBonus(bets);
+
+            Assert.All(bets.Where(b => b.Result != BetResult.NOTHING), b => Assert.Equal(2, b.DixitBonus));
+        }
+
+        [Fact]
+        public void ApplyDixitBonus_1CorrectOutOfMany_Plus3()
+        {
+            var bets = new List<MatchBet>();
+            bets.Add(new MatchBet { Result = BetResult.DIFFERENCE });
+            for (int i = 0; i < 9; i++)
+                bets.Add(new MatchBet { Result = BetResult.NOTHING });
+
+            DixitBonusCalculator.ApplyDixitBonus(bets);
+
+            Assert.Equal(3, bets[0].DixitBonus);
+            Assert.All(bets.Skip(1), b => Assert.Equal(0, b.DixitBonus));
+        }
+
+        [Fact]
+        public void ApplyDixitBonus_1BetTotal_Correct_Plus3()
+        {
+            var bets = new List<MatchBet>
+            {
+                new MatchBet { Result = BetResult.WINNER }
+            };
+
+            DixitBonusCalculator.ApplyDixitBonus(bets);
+
+            Assert.Equal(3, bets[0].DixitBonus);
+        }
+
+        // Delta bet tests
+
+        [Fact]
+        public void ApplyDixitBonus_DeltaBets_NoBets_DoesNotThrow()
+        {
+            DixitBonusCalculator.ApplyDixitBonus(new List<DeltaBet>());
+            DixitBonusCalculator.ApplyDixitBonus((List<DeltaBet>)null);
+        }
+
+        [Fact]
+        public void ApplyDixitBonus_DeltaBets_AllWrong_AllBonusZero()
+        {
+            var bets = Enumerable.Range(0, 5)
+                .Select(_ => new DeltaBet { Result = new DeltaBetResult { Points = 0 } })
+                .ToList();
+
+            DixitBonusCalculator.ApplyDixitBonus(bets);
+
+            Assert.All(bets, b => Assert.Equal(0, b.DixitBonus));
+        }
+
+        [Fact]
+        public void ApplyDixitBonus_DeltaBets_1CorrectOutOfMany_Plus3()
+        {
+            var bets = new List<DeltaBet>();
+            bets.Add(new DeltaBet { Result = new DeltaBetResult { Points = 2 } });
+            for (int i = 0; i < 9; i++)
+                bets.Add(new DeltaBet { Result = new DeltaBetResult { Points = 0 } });
+
+            DixitBonusCalculator.ApplyDixitBonus(bets);
+
+            Assert.Equal(3, bets[0].DixitBonus);
+            Assert.All(bets.Skip(1), b => Assert.Equal(0, b.DixitBonus));
+        }
+
+        [Fact]
+        public void ApplyDixitBonus_DeltaBets_39PercentCorrect_Plus1()
+        {
+            var bets = new List<DeltaBet>();
+            for (int i = 0; i < 39; i++)
+                bets.Add(new DeltaBet { Result = new DeltaBetResult { Points = 2 } });
+            for (int i = 0; i < 61; i++)
+                bets.Add(new DeltaBet { Result = new DeltaBetResult { Points = 0 } });
+
+            DixitBonusCalculator.ApplyDixitBonus(bets);
+
+            Assert.All(bets.Where(b => b.Result.Points > 0), b => Assert.Equal(1, b.DixitBonus));
+            Assert.All(bets.Where(b => b.Result.Points == 0), b => Assert.Equal(0, b.DixitBonus));
+        }
+
+        [Fact]
+        public void ApplyDixitBonus_DeltaBets_NullResult_TreatedAsWrong()
+        {
+            var bets = new List<DeltaBet>
+            {
+                new DeltaBet { Result = new DeltaBetResult { Points = 2 } },
+                new DeltaBet { Result = null },
+            };
+
+            DixitBonusCalculator.ApplyDixitBonus(bets);
+
+            Assert.Equal(3, bets[0].DixitBonus);
+            Assert.Equal(0, bets[1].DixitBonus);
+        }
+    }
+}

--- a/TipTournament2.0.Tests/Coordinator/GroupMatchesResultCoordinatorTests.cs
+++ b/TipTournament2.0.Tests/Coordinator/GroupMatchesResultCoordinatorTests.cs
@@ -102,5 +102,29 @@ namespace TipTournament2._0.Tests.Coordinator
             Assert.Equal(0, user.AlfaPoints);
             Assert.Equal(0, user.TotalPoints);
         }
+
+        [Fact]
+        public void RecalculatePoints_IncludesDixitBonus()
+        {
+            var result = new Result { HomeTeam = 2, AwayTeam = 1 };
+            var savedResult = new Result { Id = "r1", HomeTeam = 2, AwayTeam = 1 };
+            var match = new Match { Id = "m1" };
+            var user = new ApplicationUser { Id = "u1", AlfaPoints = 0, TotalPoints = 0 };
+            var bet = new MatchBet { Result = BetResult.WINNER, DixitBonus = 2 };
+
+            this.mockDb.Setup(d => d.SaveResult(result)).Returns(savedResult);
+            this.mockDb.Setup(d => d.GetMatchById("m1")).Returns(match);
+            this.mockDb.Setup(d => d.GetBetsForMatch(It.IsAny<Match>())).Returns(new List<MatchBet>());
+            this.mockBetMaker.Setup(b => b.UpdateBetResult(It.IsAny<List<MatchBet>>(), It.IsAny<Result>())).Returns(new List<MatchBet>());
+            this.mockDb.Setup(d => d.GetAllUsers()).Returns(new List<ApplicationUser> { user });
+            this.mockDb.Setup(d => d.GetBetForMatchAndUser(match, "u1")).Returns(bet);
+
+            var sut = new GroupMatchesResultCoordinator(this.mockMatchClient.Object, this.mockDb.Object, this.mockBetMaker.Object);
+            sut.UploadNewResult("m1", result);
+
+            Assert.Equal(3, user.AlfaPoints);  // 1 (WINNER) + 2 (DixitBonus)
+            Assert.Equal(3, user.TotalPoints);
+        }
     }
 }
+


### PR DESCRIPTION
Reward rare correct predictions with bonus points: +1 (<40% correct), +2 (<20% correct), +3 (only you correct). Applies to both group stage match bets (Alfa) and knockout team predictions (Delta).