### PR TITLE
Add Dixit bonus rule for knockout bets

### DIFF
--- a/ClientApp/src/components/Bets/DeltaBetRow.tsx
+++ b/ClientApp/src/components/Bets/DeltaBetRow.tsx
@@ -1,6 +1,7 @@
 ﻿import * as React from 'react';
 import { getApi } from "../api/ApiFactory"
 import { Match, DeltaBet, DeltaBetTeams } from "../../typings/index"
+import './../../custom.css';
 import { Table } from 'reactstrap';
 import { MatchBetRow } from './MatchBetRow';
 import { Loader } from '../Loader'
@@ -120,7 +121,7 @@ export class DeltaBetRow extends React.Component<DeltaBetProps, DeltaBetState> {
                         <tr>
                             <td />
                             {this.props.showResult
-                                ? <tr className={this.getBackgroundClass()}><td>Body:</td><td>{this.getTotalPoints()}</td></tr>
+                                ? <tr className={this.getBackgroundClass()}><td>Body:</td><td>{this.getTotalPointsWithBonus()}{this.state.bet.dixitBonus > 0 && <span className="dixit-bonus"> (dixit +{this.state.bet.dixitBonus})</span>}</td></tr>
                                 : this.props.isReadOnly
                                     ? <div />
                                     : this.state.isEditable
@@ -135,6 +136,10 @@ export class DeltaBetRow extends React.Component<DeltaBetProps, DeltaBetState> {
 
     private getTotalPoints(): number {
         return (this.state.bet.result?.points ?? 0) + (this.state.bet.result?.additionalResult?.points ?? 0);
+    }
+
+    private getTotalPointsWithBonus(): number {
+        return this.getTotalPoints() + (this.state.bet.dixitBonus ?? 0);
     }
 
     private getBackgroundClass(): string {

--- a/ClientApp/src/components/RulePage.tsx
+++ b/ClientApp/src/components/RulePage.tsx
@@ -183,6 +183,26 @@ export class RulePage extends React.Component<RulePageProps> {
                         <div className="rules-note">
                             <strong>Příklad:</strong> Za správně tipnutého vítěze turnaje můžeš získat celkem <strong>9 bodů</strong> (2 za čtvrtfinále + 2 za semifinále + 2 za finále + 3 za vítěze).
                         </div>
+                        <div className="rules-note">
+                            <strong>Dixit bonus:</strong> Pokud správně tipneš účastníka kola a většina hráčů se mýlí, získáváš bonusové body:
+                        </div>
+                        <div className="rules-scoring">
+                            <div className="rules-score-row">
+                                <span className="rules-points rules-points-1">+1 b.</span>
+                                <span>Méně než 40 % hráčů tiplo správně</span>
+                            </div>
+                            <div className="rules-score-row">
+                                <span className="rules-points rules-points-2">+2 b.</span>
+                                <span>Méně než 20 % hráčů tiplo správně</span>
+                            </div>
+                            <div className="rules-score-row">
+                                <span className="rules-points rules-points-3">+3 b.</span>
+                                <span>Jako jediný jsi tipnul správně</span>
+                            </div>
+                        </div>
+                        <div className="rules-note">
+                            Bonusy se nesčítají — platí vždy nejvyšší dosažený stupeň. Bonus se počítá ze všech hráčů, kteří na daný zápas tipovali.
+                        </div>
                     </div>
 
                     <div className="rules-card">

--- a/TipTournament2.0.Tests/Calculator/DixitBonusCalculatorTests.cs
+++ b/TipTournament2.0.Tests/Calculator/DixitBonusCalculatorTests.cs
@@ -8,15 +8,19 @@ namespace TipTournament2._0.Tests.Calculator
 
     public class DixitBonusCalculatorTests
     {
+        // =============================================
+        // MatchBet tests
+        // =============================================
+
         [Fact]
-        public void ApplyDixitBonus_NoBets_DoesNotThrow()
+        public void MatchBet_NoBets_DoesNotThrow()
         {
             DixitBonusCalculator.ApplyDixitBonus(new List<MatchBet>());
             DixitBonusCalculator.ApplyDixitBonus((List<MatchBet>)null);
         }
 
         [Fact]
-        public void ApplyDixitBonus_AllWrong_AllBonusZero()
+        public void MatchBet_AllWrong_AllBonusZero()
         {
             var bets = Enumerable.Range(0, 5)
                 .Select(_ => new MatchBet { Result = BetResult.NOTHING })
@@ -28,21 +32,12 @@ namespace TipTournament2._0.Tests.Calculator
         }
 
         [Fact]
-        public void ApplyDixitBonus_50PercentCorrect_NoBonus()
+        public void MatchBet_AllCorrect_NoBonus()
         {
-            var bets = new List<MatchBet>
-            {
-                new MatchBet { Result = BetResult.WINNER },
-                new MatchBet { Result = BetResult.WINNER },
-                new MatchBet { Result = BetResult.WINNER },
-                new MatchBet { Result = BetResult.WINNER },
-                new MatchBet { Result = BetResult.WINNER },
-                new MatchBet { Result = BetResult.NOTHING },
-                new MatchBet { Result = BetResult.NOTHING },
-                new MatchBet { Result = BetResult.NOTHING },
-                new MatchBet { Result = BetResult.NOTHING },
-                new MatchBet { Result = BetResult.NOTHING },
-            };
+            // 100% correct → no bonus for anyone
+            var bets = Enumerable.Range(0, 10)
+                .Select(_ => new MatchBet { Result = BetResult.WINNER })
+                .ToList();
 
             DixitBonusCalculator.ApplyDixitBonus(bets);
 
@@ -50,9 +45,56 @@ namespace TipTournament2._0.Tests.Calculator
         }
 
         [Fact]
-        public void ApplyDixitBonus_39PercentCorrect_Plus1()
+        public void MatchBet_50PercentCorrect_NoBonus()
         {
-            // 39 out of 100 = 39%
+            var bets = new List<MatchBet>();
+            for (int i = 0; i < 5; i++)
+                bets.Add(new MatchBet { Result = BetResult.WINNER });
+            for (int i = 0; i < 5; i++)
+                bets.Add(new MatchBet { Result = BetResult.NOTHING });
+
+            DixitBonusCalculator.ApplyDixitBonus(bets);
+
+            Assert.All(bets, b => Assert.Equal(0, b.DixitBonus));
+        }
+
+        // ---- Boundary: exactly 40% ----
+
+        [Fact]
+        public void MatchBet_Exactly40Percent_NoBonus()
+        {
+            // 4/10 = 0.40, NOT < 0.40 → 0 bonus
+            var bets = new List<MatchBet>();
+            for (int i = 0; i < 4; i++)
+                bets.Add(new MatchBet { Result = BetResult.WINNER });
+            for (int i = 0; i < 6; i++)
+                bets.Add(new MatchBet { Result = BetResult.NOTHING });
+
+            DixitBonusCalculator.ApplyDixitBonus(bets);
+
+            Assert.All(bets.Where(b => b.Result != BetResult.NOTHING), b => Assert.Equal(0, b.DixitBonus));
+        }
+
+        [Fact]
+        public void MatchBet_JustBelow40Percent_Plus1()
+        {
+            // 3/10 = 0.30 < 0.40 → +1 bonus
+            var bets = new List<MatchBet>();
+            for (int i = 0; i < 3; i++)
+                bets.Add(new MatchBet { Result = BetResult.WINNER });
+            for (int i = 0; i < 7; i++)
+                bets.Add(new MatchBet { Result = BetResult.NOTHING });
+
+            DixitBonusCalculator.ApplyDixitBonus(bets);
+
+            Assert.All(bets.Where(b => b.Result != BetResult.NOTHING), b => Assert.Equal(1, b.DixitBonus));
+            Assert.All(bets.Where(b => b.Result == BetResult.NOTHING), b => Assert.Equal(0, b.DixitBonus));
+        }
+
+        [Fact]
+        public void MatchBet_39of100_Plus1()
+        {
+            // 39/100 = 0.39 < 0.40 → +1
             var bets = new List<MatchBet>();
             for (int i = 0; i < 39; i++)
                 bets.Add(new MatchBet { Result = BetResult.WINNER });
@@ -65,10 +107,43 @@ namespace TipTournament2._0.Tests.Calculator
             Assert.All(bets.Where(b => b.Result == BetResult.NOTHING), b => Assert.Equal(0, b.DixitBonus));
         }
 
+        // ---- Boundary: exactly 20% ----
+
         [Fact]
-        public void ApplyDixitBonus_19PercentCorrect_Plus2()
+        public void MatchBet_Exactly20Percent_Plus1_Not_Plus2()
         {
-            // 19 out of 100 = 19%
+            // 2/10 = 0.20, NOT < 0.20 → falls to < 0.40 check → +1
+            var bets = new List<MatchBet>();
+            for (int i = 0; i < 2; i++)
+                bets.Add(new MatchBet { Result = BetResult.WINNER });
+            for (int i = 0; i < 8; i++)
+                bets.Add(new MatchBet { Result = BetResult.NOTHING });
+
+            DixitBonusCalculator.ApplyDixitBonus(bets);
+
+            Assert.All(bets.Where(b => b.Result != BetResult.NOTHING), b => Assert.Equal(1, b.DixitBonus));
+        }
+
+        [Fact]
+        public void MatchBet_JustBelow20Percent_Plus2()
+        {
+            // 1/10 = 0.10 < 0.20, but correctCount == 1 → +3 (only-you takes priority)
+            // Use 2/11 = 0.1818 < 0.20 → +2
+            var bets = new List<MatchBet>();
+            for (int i = 0; i < 2; i++)
+                bets.Add(new MatchBet { Result = BetResult.SCORE });
+            for (int i = 0; i < 9; i++)
+                bets.Add(new MatchBet { Result = BetResult.NOTHING });
+
+            DixitBonusCalculator.ApplyDixitBonus(bets);
+
+            Assert.All(bets.Where(b => b.Result != BetResult.NOTHING), b => Assert.Equal(2, b.DixitBonus));
+        }
+
+        [Fact]
+        public void MatchBet_19of100_Plus2()
+        {
+            // 19/100 = 0.19 < 0.20 → +2
             var bets = new List<MatchBet>();
             for (int i = 0; i < 19; i++)
                 bets.Add(new MatchBet { Result = BetResult.SCORE });
@@ -80,8 +155,10 @@ namespace TipTournament2._0.Tests.Calculator
             Assert.All(bets.Where(b => b.Result != BetResult.NOTHING), b => Assert.Equal(2, b.DixitBonus));
         }
 
+        // ---- "Only you" tier ----
+
         [Fact]
-        public void ApplyDixitBonus_1CorrectOutOfMany_Plus3()
+        public void MatchBet_1CorrectOutOfMany_Plus3()
         {
             var bets = new List<MatchBet>();
             bets.Add(new MatchBet { Result = BetResult.DIFFERENCE });
@@ -95,8 +172,9 @@ namespace TipTournament2._0.Tests.Calculator
         }
 
         [Fact]
-        public void ApplyDixitBonus_1BetTotal_Correct_Plus3()
+        public void MatchBet_1BetTotal_Correct_Plus3()
         {
+            // Edge case: only 1 person bet, and they're correct → +3
             var bets = new List<MatchBet>
             {
                 new MatchBet { Result = BetResult.WINNER }
@@ -107,17 +185,143 @@ namespace TipTournament2._0.Tests.Calculator
             Assert.Equal(3, bets[0].DixitBonus);
         }
 
-        // Delta bet tests
+        [Fact]
+        public void MatchBet_1CorrectOf2Total_Plus3_OnlyYouOverridesRatio()
+        {
+            // 1/2 = 50% by ratio → would be 0, but "only you" rule gives +3
+            // This is intentional: the "only you" tier always takes priority
+            var bets = new List<MatchBet>
+            {
+                new MatchBet { Result = BetResult.WINNER },
+                new MatchBet { Result = BetResult.NOTHING },
+            };
+
+            DixitBonusCalculator.ApplyDixitBonus(bets);
+
+            Assert.Equal(3, bets[0].DixitBonus);
+            Assert.Equal(0, bets[1].DixitBonus);
+        }
 
         [Fact]
-        public void ApplyDixitBonus_DeltaBets_NoBets_DoesNotThrow()
+        public void MatchBet_1CorrectOf3Total_Plus3_OnlyYouOverridesRatio()
+        {
+            // 1/3 = 33% → ratio would give +1, but "only you" gives +3
+            var bets = new List<MatchBet>
+            {
+                new MatchBet { Result = BetResult.SCORE },
+                new MatchBet { Result = BetResult.NOTHING },
+                new MatchBet { Result = BetResult.NOTHING },
+            };
+
+            DixitBonusCalculator.ApplyDixitBonus(bets);
+
+            Assert.Equal(3, bets[0].DixitBonus);
+        }
+
+        // ---- 2 correct: should NOT trigger "only you" ----
+
+        [Fact]
+        public void MatchBet_2CorrectOf6_Plus1_NotPlus3()
+        {
+            // 2/6 = 33.3% < 40% → +1, must NOT be +3
+            var bets = new List<MatchBet>();
+            for (int i = 0; i < 2; i++)
+                bets.Add(new MatchBet { Result = BetResult.WINNER });
+            for (int i = 0; i < 4; i++)
+                bets.Add(new MatchBet { Result = BetResult.NOTHING });
+
+            DixitBonusCalculator.ApplyDixitBonus(bets);
+
+            Assert.All(bets.Where(b => b.Result != BetResult.NOTHING), b => Assert.Equal(1, b.DixitBonus));
+        }
+
+        [Fact]
+        public void MatchBet_2CorrectOf20_Plus2()
+        {
+            // 2/20 = 10% < 20% → +2
+            var bets = new List<MatchBet>();
+            for (int i = 0; i < 2; i++)
+                bets.Add(new MatchBet { Result = BetResult.WINNER });
+            for (int i = 0; i < 18; i++)
+                bets.Add(new MatchBet { Result = BetResult.NOTHING });
+
+            DixitBonusCalculator.ApplyDixitBonus(bets);
+
+            Assert.All(bets.Where(b => b.Result != BetResult.NOTHING), b => Assert.Equal(2, b.DixitBonus));
+        }
+
+        // ---- Mixed BetResult types all count as "correct" ----
+
+        [Fact]
+        public void MatchBet_MixedCorrectTypes_AllGetSameBonus()
+        {
+            // WINNER(1), DIFFERENCE(2), SCORE(4) all count as correct
+            // 3/10 = 30% < 40% → +1 for all correct bets
+            var bets = new List<MatchBet>
+            {
+                new MatchBet { Result = BetResult.WINNER },
+                new MatchBet { Result = BetResult.DIFFERENCE },
+                new MatchBet { Result = BetResult.SCORE },
+            };
+            for (int i = 0; i < 7; i++)
+                bets.Add(new MatchBet { Result = BetResult.NOTHING });
+
+            DixitBonusCalculator.ApplyDixitBonus(bets);
+
+            Assert.Equal(1, bets[0].DixitBonus); // WINNER
+            Assert.Equal(1, bets[1].DixitBonus); // DIFFERENCE
+            Assert.Equal(1, bets[2].DixitBonus); // SCORE
+        }
+
+        // ---- Idempotency: calling twice should not accumulate ----
+
+        [Fact]
+        public void MatchBet_CalledTwice_DoesNotAccumulate()
+        {
+            var bets = new List<MatchBet>
+            {
+                new MatchBet { Result = BetResult.WINNER },
+                new MatchBet { Result = BetResult.NOTHING },
+            };
+
+            DixitBonusCalculator.ApplyDixitBonus(bets);
+            DixitBonusCalculator.ApplyDixitBonus(bets);
+
+            // Should still be 3, not 6
+            Assert.Equal(3, bets[0].DixitBonus);
+            Assert.Equal(0, bets[1].DixitBonus);
+        }
+
+        // ---- Wrong bets always get 0, even if pre-set ----
+
+        [Fact]
+        public void MatchBet_WrongBetWithPreExistingBonus_ResetsToZero()
+        {
+            var bets = new List<MatchBet>
+            {
+                new MatchBet { Result = BetResult.NOTHING, DixitBonus = 5 },
+                new MatchBet { Result = BetResult.WINNER },
+            };
+
+            DixitBonusCalculator.ApplyDixitBonus(bets);
+
+            Assert.Equal(0, bets[0].DixitBonus);  // must reset to 0
+            Assert.Equal(3, bets[1].DixitBonus);
+        }
+
+        // =============================================
+        // DeltaBet tests
+        // =============================================
+
+        [Fact]
+        public void DeltaBet_NoBets_DoesNotThrow()
         {
             DixitBonusCalculator.ApplyDixitBonus(new List<DeltaBet>());
             DixitBonusCalculator.ApplyDixitBonus((List<DeltaBet>)null);
         }
 
         [Fact]
-        public void ApplyDixitBonus_DeltaBets_AllWrong_AllBonusZero()
+        public void DeltaBet_AllWrong_AllBonusZero()
         {
             var bets = Enumerable.Range(0, 5)
                 .Select(_ => new DeltaBet { Result = new DeltaBetResult { Points = 0 } })
@@ -129,7 +333,19 @@ namespace TipTournament2._0.Tests.Calculator
         }
 
         [Fact]
-        public void ApplyDixitBonus_DeltaBets_1CorrectOutOfMany_Plus3()
+        public void DeltaBet_AllCorrect_NoBonus()
+        {
+            var bets = Enumerable.Range(0, 10)
+                .Select(_ => new DeltaBet { Result = new DeltaBetResult { Points = 2 } })
+                .ToList();
+
+            DixitBonusCalculator.ApplyDixitBonus(bets);
+
+            Assert.All(bets, b => Assert.Equal(0, b.DixitBonus));
+        }
+
+        [Fact]
+        public void DeltaBet_1CorrectOutOfMany_Plus3()
         {
             var bets = new List<DeltaBet>();
             bets.Add(new DeltaBet { Result = new DeltaBetResult { Points = 2 } });
@@ -143,7 +359,37 @@ namespace TipTournament2._0.Tests.Calculator
         }
 
         [Fact]
-        public void ApplyDixitBonus_DeltaBets_39PercentCorrect_Plus1()
+        public void DeltaBet_Exactly40Percent_NoBonus()
+        {
+            // 4/10 = 0.40, NOT < 0.40 → 0
+            var bets = new List<DeltaBet>();
+            for (int i = 0; i < 4; i++)
+                bets.Add(new DeltaBet { Result = new DeltaBetResult { Points = 2 } });
+            for (int i = 0; i < 6; i++)
+                bets.Add(new DeltaBet { Result = new DeltaBetResult { Points = 0 } });
+
+            DixitBonusCalculator.ApplyDixitBonus(bets);
+
+            Assert.All(bets.Where(b => b.Result.Points > 0), b => Assert.Equal(0, b.DixitBonus));
+        }
+
+        [Fact]
+        public void DeltaBet_Exactly20Percent_Plus1_Not_Plus2()
+        {
+            // 2/10 = 0.20, NOT < 0.20 → falls to < 0.40 → +1
+            var bets = new List<DeltaBet>();
+            for (int i = 0; i < 2; i++)
+                bets.Add(new DeltaBet { Result = new DeltaBetResult { Points = 4 } });
+            for (int i = 0; i < 8; i++)
+                bets.Add(new DeltaBet { Result = new DeltaBetResult { Points = 0 } });
+
+            DixitBonusCalculator.ApplyDixitBonus(bets);
+
+            Assert.All(bets.Where(b => b.Result.Points > 0), b => Assert.Equal(1, b.DixitBonus));
+        }
+
+        [Fact]
+        public void DeltaBet_39PercentCorrect_Plus1()
         {
             var bets = new List<DeltaBet>();
             for (int i = 0; i < 39; i++)
@@ -158,7 +404,7 @@ namespace TipTournament2._0.Tests.Calculator
         }
 
         [Fact]
-        public void ApplyDixitBonus_DeltaBets_NullResult_TreatedAsWrong()
+        public void DeltaBet_NullResult_TreatedAsWrong()
         {
             var bets = new List<DeltaBet>
             {
@@ -170,6 +416,154 @@ namespace TipTournament2._0.Tests.Calculator
 
             Assert.Equal(3, bets[0].DixitBonus);
             Assert.Equal(0, bets[1].DixitBonus);
+        }
+
+        // ---- Delta: partial vs full correctness get same tier ----
+
+        [Fact]
+        public void DeltaBet_PartialAndFullCorrectness_SameTier()
+        {
+            // 1 bet with 2 pts (one team right), 1 bet with 4 pts (both teams right)
+            // Both are "correct" → 2/10 = 20% → +1
+            var bets = new List<DeltaBet>
+            {
+                new DeltaBet { Result = new DeltaBetResult { Points = 2 } },
+                new DeltaBet { Result = new DeltaBetResult { Points = 4 } },
+            };
+            for (int i = 0; i < 8; i++)
+                bets.Add(new DeltaBet { Result = new DeltaBetResult { Points = 0 } });
+
+            DixitBonusCalculator.ApplyDixitBonus(bets);
+
+            Assert.Equal(1, bets[0].DixitBonus); // 2 pts
+            Assert.Equal(1, bets[1].DixitBonus); // 4 pts — same bonus tier
+        }
+
+        // ---- Delta: idempotency ----
+
+        [Fact]
+        public void DeltaBet_CalledTwice_DoesNotAccumulate()
+        {
+            var bets = new List<DeltaBet>
+            {
+                new DeltaBet { Result = new DeltaBetResult { Points = 2 } },
+                new DeltaBet { Result = new DeltaBetResult { Points = 0 } },
+            };
+
+            DixitBonusCalculator.ApplyDixitBonus(bets);
+            DixitBonusCalculator.ApplyDixitBonus(bets);
+
+            Assert.Equal(3, bets[0].DixitBonus); // still 3, not 6
+        }
+
+        // ---- Delta: wrong bet with pre-existing bonus resets ----
+
+        [Fact]
+        public void DeltaBet_WrongBetWithPreExistingBonus_ResetsToZero()
+        {
+            var bets = new List<DeltaBet>
+            {
+                new DeltaBet { Result = new DeltaBetResult { Points = 0 }, DixitBonus = 5 },
+                new DeltaBet { Result = new DeltaBetResult { Points = 2 } },
+            };
+
+            DixitBonusCalculator.ApplyDixitBonus(bets);
+
+            Assert.Equal(0, bets[0].DixitBonus);
+            Assert.Equal(3, bets[1].DixitBonus);
+        }
+
+        // =============================================
+        // Realistic tournament scenarios
+        // =============================================
+
+        [Fact]
+        public void Scenario_TypicalGroupMatch_20Players_5Correct()
+        {
+            // 5/20 = 25% < 40% → +1 for each correct bet
+            var bets = new List<MatchBet>();
+            for (int i = 0; i < 5; i++)
+                bets.Add(new MatchBet { Result = BetResult.WINNER });
+            for (int i = 0; i < 15; i++)
+                bets.Add(new MatchBet { Result = BetResult.NOTHING });
+
+            DixitBonusCalculator.ApplyDixitBonus(bets);
+
+            Assert.All(bets.Take(5), b => Assert.Equal(1, b.DixitBonus));
+            Assert.All(bets.Skip(5), b => Assert.Equal(0, b.DixitBonus));
+        }
+
+        [Fact]
+        public void Scenario_BigUpset_20Players_2Correct()
+        {
+            // 2/20 = 10% < 20% → +2
+            var bets = new List<MatchBet>();
+            for (int i = 0; i < 2; i++)
+                bets.Add(new MatchBet { Result = BetResult.WINNER });
+            for (int i = 0; i < 18; i++)
+                bets.Add(new MatchBet { Result = BetResult.NOTHING });
+
+            DixitBonusCalculator.ApplyDixitBonus(bets);
+
+            Assert.All(bets.Take(2), b => Assert.Equal(2, b.DixitBonus));
+        }
+
+        [Fact]
+        public void Scenario_MassiveUpset_20Players_1Correct()
+        {
+            // 1/20 = 5%, but correctCount == 1 → +3
+            var bets = new List<MatchBet>();
+            bets.Add(new MatchBet { Result = BetResult.SCORE });
+            for (int i = 0; i < 19; i++)
+                bets.Add(new MatchBet { Result = BetResult.NOTHING });
+
+            DixitBonusCalculator.ApplyDixitBonus(bets);
+
+            Assert.Equal(3, bets[0].DixitBonus);
+        }
+
+        [Fact]
+        public void Scenario_FavoriteWins_20Players_15Correct()
+        {
+            // 15/20 = 75% → no bonus
+            var bets = new List<MatchBet>();
+            for (int i = 0; i < 15; i++)
+                bets.Add(new MatchBet { Result = BetResult.WINNER });
+            for (int i = 0; i < 5; i++)
+                bets.Add(new MatchBet { Result = BetResult.NOTHING });
+
+            DixitBonusCalculator.ApplyDixitBonus(bets);
+
+            Assert.All(bets, b => Assert.Equal(0, b.DixitBonus));
+        }
+
+        [Fact]
+        public void Scenario_KnockoutOutsider_15Players_1Correct()
+        {
+            // Delta: 1/15, correctCount == 1 → +3
+            var bets = new List<DeltaBet>();
+            bets.Add(new DeltaBet { Result = new DeltaBetResult { Points = 4 } });
+            for (int i = 0; i < 14; i++)
+                bets.Add(new DeltaBet { Result = new DeltaBetResult { Points = 0 } });
+
+            DixitBonusCalculator.ApplyDixitBonus(bets);
+
+            Assert.Equal(3, bets[0].DixitBonus);
+        }
+
+        [Fact]
+        public void Scenario_KnockoutFavorite_15Players_10Correct()
+        {
+            // Delta: 10/15 = 66.7% → no bonus
+            var bets = new List<DeltaBet>();
+            for (int i = 0; i < 10; i++)
+                bets.Add(new DeltaBet { Result = new DeltaBetResult { Points = 2 } });
+            for (int i = 0; i < 5; i++)
+                bets.Add(new DeltaBet { Result = new DeltaBetResult { Points = 0 } });
+
+            DixitBonusCalculator.ApplyDixitBonus(bets);
+
+            Assert.All(bets, b => Assert.Equal(0, b.DixitBonus));
         }
     }
 }

--- a/TipTournament2.0.Tests/Coordinator/DeltaResultCoordinatorTests.cs
+++ b/TipTournament2.0.Tests/Coordinator/DeltaResultCoordinatorTests.cs
@@ -125,5 +125,26 @@ namespace TipTournament2._0.Tests.Coordinator
 
             this.mockBetMaker.Verify(b => b.UpdateAdditionalDeltaBetsResult(It.IsAny<List<DeltaBet>>(), It.IsAny<Match>()), Times.Never);
         }
+
+        [Fact]
+        public void RecalculatePoints_IncludesDixitBonus()
+        {
+            var match = new Match { Id = "m1", Stage = TournamentStage.Quarterfinal };
+            var tuple = new Tuple<string, string>("teamA", "teamB");
+            var user = new ApplicationUser { Id = "u1", DeltaPoints = 0, TotalPoints = 0 };
+            var deltaBet = new DeltaBet { Result = new DeltaBetResult { Points = 2 }, DixitBonus = 3 };
+
+            this.mockDb.Setup(d => d.GetMatchById("m1")).Returns(match);
+            this.mockDb.Setup(d => d.GetDeltaBetsByMatchId("m1")).Returns(new List<DeltaBet>());
+            this.mockBetMaker.Setup(b => b.UpdateDeltaBetsResult(It.IsAny<List<DeltaBet>>(), It.IsAny<Match>())).Returns(new List<DeltaBet>());
+            this.mockDb.Setup(d => d.GetAllUsers()).Returns(new List<ApplicationUser> { user });
+            this.mockDb.Setup(d => d.GetDeltaBetByMatchId("u1", "m1")).Returns(deltaBet);
+
+            var sut = this.CreateSut();
+            sut.UploadNewResult("m1", tuple);
+
+            Assert.Equal(5, user.DeltaPoints);  // 2 (Points) + 3 (DixitBonus)
+            Assert.Equal(5, user.TotalPoints);
+        }
     }
 }

--- a/TipTournament2.0.Tests/Coordinator/GroupMatchesResultCoordinatorTests.cs
+++ b/TipTournament2.0.Tests/Coordinator/GroupMatchesResultCoordinatorTests.cs
@@ -125,6 +125,117 @@ namespace TipTournament2._0.Tests.Coordinator
             Assert.Equal(3, user.AlfaPoints);  // 1 (WINNER) + 2 (DixitBonus)
             Assert.Equal(3, user.TotalPoints);
         }
+
+        [Fact]
+        public void UploadNewResult_WrongBet_DixitBonusIsZero_NoPointsAdded()
+        {
+            var result = new Result { HomeTeam = 2, AwayTeam = 1 };
+            var savedResult = new Result { Id = "r1", HomeTeam = 2, AwayTeam = 1 };
+            var match = new Match { Id = "m1" };
+            var user = new ApplicationUser { Id = "u1", AlfaPoints = 0, TotalPoints = 0 };
+            var bet = new MatchBet { Result = BetResult.NOTHING, DixitBonus = 0 };
+
+            this.mockDb.Setup(d => d.SaveResult(result)).Returns(savedResult);
+            this.mockDb.Setup(d => d.GetMatchById("m1")).Returns(match);
+            this.mockDb.Setup(d => d.GetBetsForMatch(It.IsAny<Match>())).Returns(new List<MatchBet>());
+            this.mockBetMaker.Setup(b => b.UpdateBetResult(It.IsAny<List<MatchBet>>(), It.IsAny<Result>())).Returns(new List<MatchBet>());
+            this.mockDb.Setup(d => d.GetAllUsers()).Returns(new List<ApplicationUser> { user });
+            this.mockDb.Setup(d => d.GetBetForMatchAndUser(match, "u1")).Returns(bet);
+
+            var sut = new GroupMatchesResultCoordinator(this.mockMatchClient.Object, this.mockDb.Object, this.mockBetMaker.Object);
+            sut.UploadNewResult("m1", result);
+
+            Assert.Equal(0, user.AlfaPoints);
+            Assert.Equal(0, user.TotalPoints);
+        }
+
+        [Fact]
+        public void UploadNewResult_EndToEnd_DixitBonusComputedAndAppliedToPoints()
+        {
+            // Simulates the full pipeline: UpdateBetResult sets Results on bets,
+            // then DixitBonusCalculator runs on those same bet objects,
+            // then RecalculatePoints re-fetches bets (with DixitBonus now set) and adds to user points.
+            var result = new Result { HomeTeam = 2, AwayTeam = 1 };
+            var savedResult = new Result { Id = "r1", HomeTeam = 2, AwayTeam = 1 };
+            var match = new Match { Id = "m1" };
+
+            var userA = new ApplicationUser { Id = "uA", AlfaPoints = 10, TotalPoints = 20 };
+            var userB = new ApplicationUser { Id = "uB", AlfaPoints = 5, TotalPoints = 15 };
+
+            // These are the bets that UpdateBetsResult will work with.
+            // BetResultMaker sets the Result field; DixitBonusCalculator then sets DixitBonus.
+            var betA = new MatchBet { Result = BetResult.NOTHING }; // will remain NOTHING
+            var betB = new MatchBet { Result = BetResult.NOTHING }; // will remain NOTHING
+            var allBets = new List<MatchBet> { betA, betB };
+
+            // BetResultMaker mock: simulates setting results. Only betB is correct.
+            this.mockBetMaker.Setup(b => b.UpdateBetResult(allBets, savedResult))
+                .Callback<List<MatchBet>, Result>((bets, r) =>
+                {
+                    bets[0].Result = BetResult.NOTHING;  // userA wrong
+                    bets[1].Result = BetResult.WINNER;    // userB correct (only 1 correct of 2 → +3)
+                })
+                .Returns(allBets);
+
+            this.mockDb.Setup(d => d.SaveResult(result)).Returns(savedResult);
+            this.mockDb.Setup(d => d.GetMatchById("m1")).Returns(match);
+            this.mockDb.Setup(d => d.GetBetsForMatch(It.IsAny<Match>())).Returns(allBets);
+            this.mockDb.Setup(d => d.GetAllUsers()).Returns(new List<ApplicationUser> { userA, userB });
+
+            // RecalculatePoints re-fetches bets from DB. We return the SAME objects
+            // (simulating that DixitBonus was persisted by UpdateBets and then read back).
+            this.mockDb.Setup(d => d.GetBetForMatchAndUser(match, "uA")).Returns(betA);
+            this.mockDb.Setup(d => d.GetBetForMatchAndUser(match, "uB")).Returns(betB);
+
+            var sut = new GroupMatchesResultCoordinator(this.mockMatchClient.Object, this.mockDb.Object, this.mockBetMaker.Object);
+            sut.UploadNewResult("m1", result);
+
+            // After UpdateBetsResult: betB.Result = WINNER, betB.DixitBonus = 3 (only 1 correct of 2)
+            Assert.Equal(BetResult.NOTHING, betA.Result);
+            Assert.Equal(0, betA.DixitBonus);
+            Assert.Equal(BetResult.WINNER, betB.Result);
+            Assert.Equal(3, betB.DixitBonus);
+
+            // userA: no points added (wrong bet)
+            Assert.Equal(10, userA.AlfaPoints);
+            Assert.Equal(20, userA.TotalPoints);
+
+            // userB: 1 (WINNER) + 3 (DixitBonus) = 4 added
+            Assert.Equal(9, userB.AlfaPoints);   // 5 + 4
+            Assert.Equal(19, userB.TotalPoints);  // 15 + 4
+        }
+
+        [Fact]
+        public void UploadNewResult_EndToEnd_MultipleCorrect_NoDixitBonus()
+        {
+            // 8 out of 10 correct → 80% → no Dixit bonus
+            var result = new Result { HomeTeam = 1, AwayTeam = 0 };
+            var savedResult = new Result { Id = "r1", HomeTeam = 1, AwayTeam = 0 };
+            var match = new Match { Id = "m1" };
+
+            var allBets = new List<MatchBet>();
+            for (int i = 0; i < 10; i++)
+                allBets.Add(new MatchBet { Result = BetResult.NOTHING });
+
+            this.mockBetMaker.Setup(b => b.UpdateBetResult(allBets, savedResult))
+                .Callback<List<MatchBet>, Result>((bets, r) =>
+                {
+                    for (int i = 0; i < 8; i++) bets[i].Result = BetResult.WINNER;
+                    // bets[8] and bets[9] stay NOTHING
+                })
+                .Returns(allBets);
+
+            this.mockDb.Setup(d => d.SaveResult(result)).Returns(savedResult);
+            this.mockDb.Setup(d => d.GetMatchById("m1")).Returns(match);
+            this.mockDb.Setup(d => d.GetBetsForMatch(It.IsAny<Match>())).Returns(allBets);
+            this.mockDb.Setup(d => d.GetAllUsers()).Returns(new List<ApplicationUser>());
+
+            var sut = new GroupMatchesResultCoordinator(this.mockMatchClient.Object, this.mockDb.Object, this.mockBetMaker.Object);
+            sut.UploadNewResult("m1", result);
+
+            // All bets should have 0 DixitBonus (80% correct)
+            Assert.All(allBets, b => Assert.Equal(0, b.DixitBonus));
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds Dixit bonus scoring for match and delta bets — players who correctly predict a knockout round participant that most others miss earn bonus points (+1 if <40% correct, +2 if <20%, +3 if unique)
- Includes comprehensive backend tests for bonus calculation, boundaries, and edge cases
- Updates frontend to display Dixit bonus in delta bet results and documents the rule on the Rules page

## Test plan
- [x] Unit tests for DixitBonus calculation logic (boundaries, edge cases)
- [x] DeltaResultCoordinator integration test for bonus in points calculation
- [x] Manual verification of bonus display in delta bet UI
- [x] Verify rules page renders correctly with new Dixit bonus section

🤖 Generated with [Claude Code](https://claude.com/claude-code)