### PR TITLE
Add Joker feature for group stage bets

### DIFF
--- a/ClientApp/src/components/Bets/Bets.tsx
+++ b/ClientApp/src/components/Bets/Bets.tsx
@@ -6,10 +6,15 @@ import { MatchBetRow } from './MatchBetRow';
 import { Loader } from './../Loader'
 import { Dictionary, IDictionary } from "../../typings/Dictionary"
 
+interface JokerSelection {
+    [round: number]: string; // round -> matchId
+}
+
 interface BetsState {
     matches: Match[],
     bets: IDictionary<Bet[]>,
     loading: boolean,
+    jokerSelection: JokerSelection,
 }
 
 interface BetsProps {
@@ -25,6 +30,7 @@ export class Bets extends React.Component<BetsProps, BetsState> {
             matches: {} as Match[],
             bets: new Dictionary(),
             loading: true,
+            jokerSelection: {},
         }
     }
 
@@ -47,7 +53,20 @@ export class Bets extends React.Component<BetsProps, BetsState> {
     private async getData() {
         const matches = await getApi().getMatches(TournamentStage.Group);
         let userBets: IDictionary<Bet[]> = !!this.props.users ? await this.getBetsForMultipleUsers(this.props.users) : await this.getBetsForCurrentUser();
-        this.setState({ matches: matches, bets: userBets, loading: false });
+
+        // Initialize joker selection from existing bet data
+        const jokerSelection: JokerSelection = {};
+        const currentBets = userBets.get("current");
+        if (currentBets) {
+            currentBets.forEach(b => {
+                if (b.isJoker && b.match) {
+                    const round = b.match.round || 0;
+                    jokerSelection[round] = b.match.id;
+                }
+            });
+        }
+
+        this.setState({ matches: matches, bets: userBets, loading: false, jokerSelection: jokerSelection });
     }
 
     private async getBetsForCurrentUser(): Promise<IDictionary<Bet[]>> {
@@ -66,6 +85,51 @@ export class Bets extends React.Component<BetsProps, BetsState> {
     private isMatchLocked(match: Match): boolean {
         if (!match.startTime) return false;
         return new Date() > new Date(match.startTime);
+    }
+
+    private getMatchesForRound(matches: Match[], round: number): Match[] {
+        return matches.filter(m => (m.round || 0) === round);
+    }
+
+    private getRounds(matches: Match[]): number[] {
+        const rounds = matches.map(m => m.round || 0)
+            .filter((value, index, self) => self.indexOf(value) === index);
+        return rounds.sort((a, b) => a - b);
+    }
+
+    private hasBetForMatch(matchId: string): boolean {
+        const currentBets = this.state.bets.get("current");
+        if (!currentBets) return false;
+        return currentBets.some(b => b.match && b.match.id === matchId);
+    }
+
+    private handleJokerToggle(matchId: string, round: number) {
+        // Update local state immediately for instant UI feedback
+        const jokerSelection = { ...this.state.jokerSelection };
+        jokerSelection[round] = matchId;
+        this.setState({ jokerSelection });
+
+        // If bet already exists on server, persist joker immediately
+        if (this.hasBetForMatch(matchId)) {
+            getApi().setJoker(matchId);
+        }
+    }
+
+    private async handleBetSaved(matchId: string) {
+        // Find the round for this match
+        const match = this.state.matches.find(m => m.id === matchId);
+        const round = match ? (match.round || 0) : 0;
+
+        // If this match is the selected joker for its round, persist it now
+        if (this.state.jokerSelection[round] === matchId) {
+            await getApi().setJoker(matchId);
+        }
+
+        // Refresh bets from server to sync state
+        const bets = await getApi().getBets(undefined);
+        let userBets = this.state.bets;
+        userBets.put("current", bets);
+        this.setState({ bets: userBets });
     }
 
     private renderBetsTable(matches: Match[], userBets: IDictionary<Bet[]>) {
@@ -111,18 +175,47 @@ export class Bets extends React.Component<BetsProps, BetsState> {
     }
 
     private renderBetsTableForCurrentUser(matches: Match[], userBets: IDictionary<Bet[]>) {
+        const rounds = this.getRounds(matches);
+
         return (
-            <Table className="table table-striped table-bordered">
-                <thead>
-                </thead>
-                <tbody>
-                    {matches.map((match, index) => (
-                        <tr key={match.id}>
-                            <MatchBetRow match={match} bets={this.getBetsRow(userBets, match)} isReadOnly={this.isMatchLocked(match)} />
-                        </tr>)
-                    )}
-                </tbody>
-            </Table>
+            <div>
+                {rounds.map(round => {
+                    const roundMatches = this.getMatchesForRound(matches, round);
+                    const jokerMatchId = this.state.jokerSelection[round] || null;
+                    // If joker is on a match that already started, lock joker for entire round
+                    const jokerMatch = jokerMatchId ? roundMatches.find(m => m.id === jokerMatchId) : null;
+                    const isRoundJokerLocked = jokerMatch ? this.isMatchLocked(jokerMatch) : false;
+                    return (
+                        <div key={round} className="mb-3">
+                            {round > 0 && <h5>Kolo {round}</h5>}
+                            <Table className="table table-striped table-bordered">
+                                <thead>
+                                </thead>
+                                <tbody>
+                                    {roundMatches.map((match) => {
+                                        const bets = this.getBetsRow(userBets, match);
+                                        const isLocked = this.isMatchLocked(match);
+                                        const isJoker = jokerMatchId === match.id;
+                                        return (
+                                            <tr key={match.id} className={isJoker ? 'joker-bet' : ''}>
+                                                <MatchBetRow
+                                                    match={match}
+                                                    bets={bets}
+                                                    isReadOnly={isLocked}
+                                                    isJoker={isJoker}
+                                                    canSetJoker={!isLocked && !isRoundJokerLocked}
+                                                    onJokerToggle={() => this.handleJokerToggle(match.id, round)}
+                                                    onBetSaved={() => this.handleBetSaved(match.id)}
+                                                />
+                                            </tr>
+                                        );
+                                    })}
+                                </tbody>
+                            </Table>
+                        </div>
+                    );
+                })}
+            </div>
         );
     }
 }

--- a/ClientApp/src/components/Bets/MatchBetRow.tsx
+++ b/ClientApp/src/components/Bets/MatchBetRow.tsx
@@ -1,4 +1,4 @@
-﻿import * as React from 'react';
+import * as React from 'react';
 import { getApi } from "../api/ApiFactory"
 import { Bet, Match, Result } from "../../typings/index"
 import { TeamCell } from './../TeamCell'
@@ -11,7 +11,11 @@ interface MatchBetRowState {
 interface MatchBetRowProps {
     match: Match,
     bets: Bet[] | undefined,
-    isReadOnly: boolean
+    isReadOnly: boolean,
+    isJoker?: boolean,
+    canSetJoker?: boolean,
+    onJokerToggle?: () => void,
+    onBetSaved?: () => void
 }
 
 export class MatchBetRow extends React.Component<MatchBetRowProps, MatchBetRowState> {
@@ -42,6 +46,29 @@ export class MatchBetRow extends React.Component<MatchBetRowProps, MatchBetRowSt
         return `${date.getDate()}.${date.getMonth() + 1}. ${date.getHours().toString().padStart(2, '0')}:${date.getMinutes().toString().padStart(2, '0')}`;
     }
 
+    private renderJokerButton() {
+        if (this.props.canSetJoker && this.props.onJokerToggle) {
+            return (
+                <td>
+                    <button
+                        className={`btn btn-sm ${this.props.isJoker ? 'btn-warning' : 'btn-outline-warning'}`}
+                        onClick={this.props.onJokerToggle}
+                        title={this.props.isJoker ? 'Joker nastaven' : 'Nastavit Joker'}
+                    >
+                        {this.props.isJoker ? '\u2605 Joker' : '\u2606'}
+                    </button>
+                </td>
+            );
+        }
+        if (this.props.isJoker) {
+            return <td><span className="joker-badge">{'\u2605'} 2x</span></td>;
+        }
+        if (this.props.canSetJoker !== undefined) {
+            return <td></td>;
+        }
+        return null;
+    }
+
     private renderSettedBet() {
         return (
             <React.Fragment>
@@ -51,7 +78,8 @@ export class MatchBetRow extends React.Component<MatchBetRowProps, MatchBetRowSt
                 {this.state.tips.map((tip) => {
                     return (<td key={tip.id}>{tip.homeTeam} : {tip.awayTeam}</td>)
                 })}
-                {!this.isMatchLocked() ? <td><button className="btn btn-link" onClick={() => this.modify()}>Upravit</button></td> : null} 
+                {!this.isMatchLocked() ? <td><button className="btn btn-link" onClick={() => this.modify()}>Upravit</button></td> : null}
+                {this.renderJokerButton()}
             </React.Fragment>
         );
     }
@@ -71,6 +99,7 @@ export class MatchBetRow extends React.Component<MatchBetRowProps, MatchBetRowSt
                 ) : (
                     <td>-</td>
                 )}
+                {this.renderJokerButton()}
             </React.Fragment>
         );
     }
@@ -89,8 +118,11 @@ export class MatchBetRow extends React.Component<MatchBetRowProps, MatchBetRowSt
 
     private async uploadTip() {
         if (this.isMatchLocked()) return;
-        this.setState({ setted: true })
-        getApi().uploadTip(this.state.tips[0], this.props.match.id);
+        this.setState({ setted: true });
+        await getApi().uploadTip(this.state.tips[0], this.props.match.id);
+        if (this.props.onBetSaved) {
+            this.props.onBetSaved();
+        }
     }
 
     private modify() {
@@ -98,4 +130,3 @@ export class MatchBetRow extends React.Component<MatchBetRowProps, MatchBetRowSt
         this.setState({ setted: false });
     }
 }
-

--- a/ClientApp/src/components/MainPage/UserBetRow.tsx
+++ b/ClientApp/src/components/MainPage/UserBetRow.tsx
@@ -23,9 +23,12 @@ export class UserBetRow extends React.Component<UserBetRowProps> {
 
         return (
             <>
-                <td className={classNames.textClass}>{bet.tip.homeTeam} : {bet.tip.awayTeam}</td>
+                <td className={classNames.textClass}>
+                    {bet.isJoker && <span className="joker-badge">{'\u2605'}</span>}{' '}
+                    {bet.tip.homeTeam} : {bet.tip.awayTeam}
+                </td>
                 <td className={classNames.bgClass}>
-                    {bet.result}
+                    {bet.isJoker && bet.result !== BetResult.nothing ? bet.result * 2 : bet.result}
                     {bet.dixitBonus > 0 && <span className="dixit-bonus">+{bet.dixitBonus}</span>}
                 </td>
             </>
@@ -41,7 +44,10 @@ export class UserBetRow extends React.Component<UserBetRowProps> {
     private renderBetSetted() {
         return (
             <>
-                <td>{this.props.bet.tip.homeTeam} : {this.props.bet.tip.awayTeam}</td>
+                <td>
+                    {this.props.bet.isJoker && <span className="joker-badge">{'\u2605'}</span>}{' '}
+                    {this.props.bet.tip.homeTeam} : {this.props.bet.tip.awayTeam}
+                </td>
                 <td />
             </>
         );

--- a/ClientApp/src/components/RulePage.tsx
+++ b/ClientApp/src/components/RulePage.tsx
@@ -150,6 +150,26 @@ export class RulePage extends React.Component<RulePageProps> {
                         <div className="rules-note">
                             Bonusy se nesčítají — platí vždy nejvyšší dosažený stupeň. Bonus se počítá ze všech hráčů, kteří na daný zápas tipovali.
                         </div>
+                        <div className="rules-note">
+                            <strong>Joker:</strong> V každém kole skupinové fáze (3 kola) můžeš označit jeden tip jako Joker. Pokud je tip správný, základní body se zdvojnásobí:
+                        </div>
+                        <div className="rules-scoring">
+                            <div className="rules-score-row">
+                                <span className="rules-points rules-points-2">1 &rarr; 2 b.</span>
+                                <span>Správný vítěz s Jokerem</span>
+                            </div>
+                            <div className="rules-score-row">
+                                <span className="rules-points rules-points-4">2 &rarr; 4 b.</span>
+                                <span>Správný rozdíl s Jokerem</span>
+                            </div>
+                            <div className="rules-score-row">
+                                <span className="rules-points rules-points-4">4 &rarr; 8 b.</span>
+                                <span>Přesný výsledek s Jokerem</span>
+                            </div>
+                        </div>
+                        <div className="rules-note">
+                            Dixit bonus se Jokerem neovlivňuje — přičítá se zvlášť k již zdvojnásobeným bodům. Joker lze měnit až do začátku zápasu.
+                        </div>
                     </div>
 
                     <div className="rules-card">

--- a/ClientApp/src/components/api/Api.ts
+++ b/ClientApp/src/components/api/Api.ts
@@ -84,6 +84,10 @@ export class Api implements IApi {
         return convert<any>(post(`${API_URL}/bets/users?userIds`, users.map((user) => { if (!!user) { return user.id } })))
     }
 
+    async setJoker(matchId: string): Promise<void> {
+        await post(`${API_URL}/bets/joker?matchId=${matchId}`);
+    }
+
     async uploadTip(tip: Result, matchId: string): Promise<void> {
         await post(`${API_URL}/bets/tip/`, { tip: tip, matchId: matchId });
     }

--- a/ClientApp/src/components/api/IApi.d.ts
+++ b/ClientApp/src/components/api/IApi.d.ts
@@ -25,4 +25,5 @@ export interface IApi {
     getGroupTeams(groupId: string): Promise<Team[]>;
     getGroups(): Promise<Group[]>
     uploadGroupBet(bet: GroupBet, groupId: string): Promise<void>;
+    setJoker(matchId: string): Promise<void>;
 }

--- a/ClientApp/src/custom.css
+++ b/ClientApp/src/custom.css
@@ -200,6 +200,22 @@ code {
     margin-left: 0.25rem;
 }
 
+/* ===== Joker Bet ===== */
+
+.joker-bet {
+    background-color: rgba(255, 215, 0, 0.15) !important;
+}
+
+.joker-badge {
+    display: inline-block;
+    background: #ffc107;
+    color: #7b5e00;
+    font-size: 0.75rem;
+    font-weight: 700;
+    padding: 0.15rem 0.5rem;
+    border-radius: 999px;
+}
+
 /* ===== Rules Page ===== */
 
 .rules-page {

--- a/ClientApp/src/typings/index.ts
+++ b/ClientApp/src/typings/index.ts
@@ -14,6 +14,7 @@ export interface Match {
     ended: boolean;
     link: string;
     stage: TournamentStage;
+    round: number;
 }
 
 export interface Team {
@@ -41,6 +42,7 @@ export interface Bet {
     tip: Result;
     result: BetResult;
     dixitBonus: number;
+    isJoker: boolean;
     user: User;
 }
 

--- a/Controllers/BetsController.cs
+++ b/Controllers/BetsController.cs
@@ -214,6 +214,54 @@ namespace TipTournament2._0.Controllers
             return new OkObjectResult(this.context.GetShooterBet(userId));
         }
 
+        [HttpPost("joker")]
+        public IActionResult SetJoker([FromQuery] string matchId)
+        {
+            var match = this.context.GetMatchById(matchId);
+            if (match == null)
+            {
+                return BadRequest("Zápas nebyl nalezen.");
+            }
+
+            if (match.Stage != TournamentStage.Group)
+            {
+                return BadRequest("Joker lze nastavit pouze na skupinové zápasy.");
+            }
+
+            if (DateTime.UtcNow >= match.StartTime)
+            {
+                return BadRequest("Zápas již začal, Joker nelze změnit.");
+            }
+
+            var userId = this.GetUserId();
+
+            // Get all bets for this round — the target bet must be among them
+            var roundBets = this.context.GetBetsForUserAndRound(userId, match.Round);
+            var targetBet = roundBets.FirstOrDefault(b => b.Match != null && b.Match.Id == matchId);
+            if (targetBet == null)
+            {
+                return BadRequest("Nejprve musíš zadat tip na tento zápas.");
+            }
+
+            // If existing joker in this round is on a match that already started, round is locked
+            var existingJoker = roundBets.FirstOrDefault(b => b.IsJoker);
+            if (existingJoker != null && existingJoker.Match != null && DateTime.UtcNow >= existingJoker.Match.StartTime)
+            {
+                return BadRequest("Joker v tomto kole je již uzamčen — zápas s Jokerem již začal.");
+            }
+
+            // Clear existing Joker in the same round, then set on target
+            foreach (var roundBet in roundBets)
+            {
+                roundBet.IsJoker = false;
+            }
+
+            targetBet.IsJoker = true;
+            this.context.UpdateBets(roundBets);
+
+            return new OkResult();
+        }
+
         [HttpPost("users")]
         public IActionResult GetBets([FromBody] string[] userIds)
         {

--- a/Coordinator/GroupMatchesResultCoordinator.cs
+++ b/Coordinator/GroupMatchesResultCoordinator.cs
@@ -49,8 +49,11 @@
                 var betForUser = this.dbContextWrapper.GetBetForMatchAndUser(match, user.Id);
                 if (betForUser != null)
                 {
-                    user.AlfaPoints += (int)betForUser.Result + betForUser.DixitBonus;
-                    user.TotalPoints += (int)betForUser.Result + betForUser.DixitBonus;
+                    var basePoints = (int)betForUser.Result;
+                    var jokerMultiplier = betForUser.IsJoker && betForUser.Result != BetResult.NOTHING ? 2 : 1;
+                    var totalPoints = (basePoints * jokerMultiplier) + betForUser.DixitBonus;
+                    user.AlfaPoints += totalPoints;
+                    user.TotalPoints += totalPoints;
                 }
             }
 

--- a/Data/DbContextWrapper.cs
+++ b/Data/DbContextWrapper.cs
@@ -598,5 +598,26 @@
         {
             return this.dbContext.Teams.ToList();
         }
+
+        public List<MatchBet> GetBetsForUserAndRound(string userId, int round)
+        {
+            return this.dbContext.Bets
+                .Include(b => b.Match)
+                .Include(b => b.User)
+                .Where(b => b.User.Id == userId)
+                .Where(b => b.Match.Stage == TournamentStage.Group)
+                .Where(b => b.Match.Round == round)
+                .ToList();
+        }
+
+        public MatchBet GetBetByMatchAndUser(string matchId, string userId)
+        {
+            return this.dbContext.Bets
+                .Include(b => b.Match)
+                .Include(b => b.User)
+                .Where(b => b.Match.Id == matchId)
+                .Where(b => b.User.Id == userId)
+                .FirstOrDefault();
+        }
     }
 }

--- a/Data/IDbContextWrapper.cs
+++ b/Data/IDbContextWrapper.cs
@@ -102,5 +102,9 @@
         DateTime GetStageStartTime(TournamentStage stage);
 
         List<Team> GetAllTeams();
+
+        List<MatchBet> GetBetsForUserAndRound(string userId, int round);
+
+        MatchBet GetBetByMatchAndUser(string matchId, string userId);
     }
 }

--- a/Data/Migrations/20260410210425_AddRoundToMatch.Designer.cs
+++ b/Data/Migrations/20260410210425_AddRoundToMatch.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TipTournament2._0.Data;
 
 namespace TipTournament2._0.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260410210425_AddRoundToMatch")]
+    partial class AddRoundToMatch
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Data/Migrations/20260410210425_AddRoundToMatch.cs
+++ b/Data/Migrations/20260410210425_AddRoundToMatch.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace TipTournament2._0.Data.Migrations
+{
+    public partial class AddRoundToMatch : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Round",
+                table: "Matches",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsJoker",
+                table: "Bets",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Round",
+                table: "Matches");
+
+            migrationBuilder.DropColumn(
+                name: "IsJoker",
+                table: "Bets");
+        }
+    }
+}

--- a/Data/Migrations/20260410210444_AddIsJokerToMatchBet.Designer.cs
+++ b/Data/Migrations/20260410210444_AddIsJokerToMatchBet.Designer.cs
@@ -3,15 +3,17 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TipTournament2._0.Data;
 
 namespace TipTournament2._0.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260410210444_AddIsJokerToMatchBet")]
+    partial class AddIsJokerToMatchBet
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Data/Migrations/20260410210444_AddIsJokerToMatchBet.cs
+++ b/Data/Migrations/20260410210444_AddIsJokerToMatchBet.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace TipTournament2._0.Data.Migrations
+{
+    public partial class AddIsJokerToMatchBet : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}

--- a/Models/Match.cs
+++ b/Models/Match.cs
@@ -32,5 +32,7 @@
         public string Link { get; set; }
 
         public TournamentStage Stage { get; set; }
+
+        public int Round { get; set; }
     }
 }

--- a/Models/MatchBet.cs
+++ b/Models/MatchBet.cs
@@ -25,5 +25,7 @@
         public BetResult Result { get; set; }
 
         public int DixitBonus { get; set; }
+
+        public bool IsJoker { get; set; }
     }
 }

--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -21,7 +21,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "https://localhost:5001;http://localhost:5000"
+      "applicationUrl": "https://localhost:5201;http://localhost:5200"
     }
   }
 }

--- a/TipTournament2.0.Tests/Controllers/BetsControllerJokerTests.cs
+++ b/TipTournament2.0.Tests/Controllers/BetsControllerJokerTests.cs
@@ -1,0 +1,413 @@
+namespace TipTournament2._0.Tests.Controllers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Security.Claims;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.AspNetCore.Mvc;
+    using Moq;
+    using TipTournament2._0.Controllers;
+    using TipTournament2._0.Data;
+    using TipTournament2._0.Models;
+    using TipTournament2._0.Utils;
+    using Xunit;
+    using Match = TipTournament2._0.Models.Match;
+
+    public class BetsControllerJokerTests
+    {
+        private readonly Mock<IDbContextWrapper> mockDb = new Mock<IDbContextWrapper>();
+        private readonly Mock<ITeamGenerator> mockTeamGen = new Mock<ITeamGenerator>();
+
+        private BetsController CreateSut()
+        {
+            var controller = new BetsController(this.mockDb.Object, this.mockTeamGen.Object);
+
+            var claims = new List<Claim> { new Claim(ClaimTypes.NameIdentifier, "test-user") };
+            var identity = new ClaimsIdentity(claims, "TestAuth");
+            var principal = new ClaimsPrincipal(identity);
+            controller.ControllerContext = new ControllerContext
+            {
+                HttpContext = new DefaultHttpContext { User = principal }
+            };
+
+            return controller;
+        }
+
+        #region Validation: match must exist
+
+        [Fact]
+        public void SetJoker_MatchNotFound_ReturnsBadRequest()
+        {
+            this.mockDb.Setup(d => d.GetMatchById("m1")).Returns((Match)null);
+
+            var sut = this.CreateSut();
+            var result = sut.SetJoker("m1");
+
+            Assert.IsType<BadRequestObjectResult>(result);
+            this.mockDb.Verify(d => d.UpdateBets(It.IsAny<List<MatchBet>>()), Times.Never);
+        }
+
+        #endregion
+
+        #region Validation: only group stage matches allowed
+
+        [Fact]
+        public void SetJoker_NotGroupMatch_ReturnsBadRequest()
+        {
+            var match = new Match { Id = "m1", Stage = TournamentStage.Quarterfinal, StartTime = DateTime.UtcNow.AddHours(1) };
+            this.mockDb.Setup(d => d.GetMatchById("m1")).Returns(match);
+
+            var sut = this.CreateSut();
+            var result = sut.SetJoker("m1");
+
+            Assert.IsType<BadRequestObjectResult>(result);
+            this.mockDb.Verify(d => d.UpdateBets(It.IsAny<List<MatchBet>>()), Times.Never);
+        }
+
+        [Theory]
+        [InlineData(TournamentStage.FirstRound)]
+        [InlineData(TournamentStage.Quarterfinal)]
+        [InlineData(TournamentStage.Semifinal)]
+        [InlineData(TournamentStage.Final)]
+        public void SetJoker_AllKnockoutStages_ReturnsBadRequest(TournamentStage stage)
+        {
+            var match = new Match { Id = "m1", Stage = stage, StartTime = DateTime.UtcNow.AddHours(1) };
+            this.mockDb.Setup(d => d.GetMatchById("m1")).Returns(match);
+
+            var sut = this.CreateSut();
+            var result = sut.SetJoker("m1");
+
+            Assert.IsType<BadRequestObjectResult>(result);
+        }
+
+        #endregion
+
+        #region Validation: match must not have started
+
+        [Fact]
+        public void SetJoker_MatchAlreadyStarted_ReturnsBadRequest()
+        {
+            var match = new Match { Id = "m1", Stage = TournamentStage.Group, StartTime = DateTime.UtcNow.AddHours(-1), Round = 1 };
+            this.mockDb.Setup(d => d.GetMatchById("m1")).Returns(match);
+
+            var sut = this.CreateSut();
+            var result = sut.SetJoker("m1");
+
+            Assert.IsType<BadRequestObjectResult>(result);
+            this.mockDb.Verify(d => d.UpdateBets(It.IsAny<List<MatchBet>>()), Times.Never);
+        }
+
+        [Fact]
+        public void SetJoker_MatchStartedExactlyNow_ReturnsBadRequest()
+        {
+            // Edge case: StartTime == UtcNow (>= check)
+            var match = new Match { Id = "m1", Stage = TournamentStage.Group, StartTime = DateTime.UtcNow, Round = 1 };
+            this.mockDb.Setup(d => d.GetMatchById("m1")).Returns(match);
+
+            var sut = this.CreateSut();
+            var result = sut.SetJoker("m1");
+
+            Assert.IsType<BadRequestObjectResult>(result);
+        }
+
+        #endregion
+
+        #region Validation: user must have a bet on the match
+
+        [Fact]
+        public void SetJoker_NoBetOnMatch_ReturnsBadRequest()
+        {
+            var match = new Match { Id = "m1", Stage = TournamentStage.Group, StartTime = DateTime.UtcNow.AddHours(1), Round = 1 };
+            this.mockDb.Setup(d => d.GetMatchById("m1")).Returns(match);
+            // Return round bets but none for this specific match
+            this.mockDb.Setup(d => d.GetBetsForUserAndRound("test-user", 1)).Returns(new List<MatchBet>());
+
+            var sut = this.CreateSut();
+            var result = sut.SetJoker("m1");
+
+            Assert.IsType<BadRequestObjectResult>(result);
+            this.mockDb.Verify(d => d.UpdateBets(It.IsAny<List<MatchBet>>()), Times.Never);
+        }
+
+        [Fact]
+        public void SetJoker_OtherBetsExistButNotForThisMatch_ReturnsBadRequest()
+        {
+            var match = new Match { Id = "m1", Stage = TournamentStage.Group, StartTime = DateTime.UtcNow.AddHours(1), Round = 1 };
+            var otherMatch = new Match { Id = "m2" };
+            var otherBet = new MatchBet { Id = "b2", Match = otherMatch, IsJoker = false };
+
+            this.mockDb.Setup(d => d.GetMatchById("m1")).Returns(match);
+            this.mockDb.Setup(d => d.GetBetsForUserAndRound("test-user", 1)).Returns(new List<MatchBet> { otherBet });
+
+            var sut = this.CreateSut();
+            var result = sut.SetJoker("m1");
+
+            Assert.IsType<BadRequestObjectResult>(result);
+            this.mockDb.Verify(d => d.UpdateBets(It.IsAny<List<MatchBet>>()), Times.Never);
+        }
+
+        #endregion
+
+        #region Happy path: sets joker and clears previous
+
+        [Fact]
+        public void SetJoker_ValidRequest_SetsJokerAndClearsPrevious()
+        {
+            var targetMatch = new Match { Id = "m1" };
+            var otherMatch = new Match { Id = "m2", StartTime = DateTime.UtcNow.AddHours(2) };
+            var match = new Match { Id = "m1", Stage = TournamentStage.Group, StartTime = DateTime.UtcNow.AddHours(1), Round = 1 };
+
+            var targetBet = new MatchBet { Id = "b1", Match = targetMatch, IsJoker = false };
+            var previousJokerBet = new MatchBet { Id = "b2", Match = otherMatch, IsJoker = true };
+            var roundBets = new List<MatchBet> { targetBet, previousJokerBet };
+
+            this.mockDb.Setup(d => d.GetMatchById("m1")).Returns(match);
+            this.mockDb.Setup(d => d.GetBetsForUserAndRound("test-user", 1)).Returns(roundBets);
+
+            var sut = this.CreateSut();
+            var result = sut.SetJoker("m1");
+
+            Assert.IsType<OkResult>(result);
+            Assert.True(targetBet.IsJoker);
+            Assert.False(previousJokerBet.IsJoker);
+            this.mockDb.Verify(d => d.UpdateBets(roundBets), Times.Once);
+        }
+
+        [Fact]
+        public void SetJoker_NoPreviousJoker_SetsJokerOnTarget()
+        {
+            var targetMatch = new Match { Id = "m1" };
+            var match = new Match { Id = "m1", Stage = TournamentStage.Group, StartTime = DateTime.UtcNow.AddHours(1), Round = 2 };
+            var bet = new MatchBet { Id = "b1", Match = targetMatch, IsJoker = false };
+            var roundBets = new List<MatchBet> { bet };
+
+            this.mockDb.Setup(d => d.GetMatchById("m1")).Returns(match);
+            this.mockDb.Setup(d => d.GetBetsForUserAndRound("test-user", 2)).Returns(roundBets);
+
+            var sut = this.CreateSut();
+            var result = sut.SetJoker("m1");
+
+            Assert.IsType<OkResult>(result);
+            Assert.True(bet.IsJoker);
+            this.mockDb.Verify(d => d.UpdateBets(roundBets), Times.Once);
+        }
+
+        #endregion
+
+        #region Re-setting joker on same match (idempotent)
+
+        [Fact]
+        public void SetJoker_AlreadyJokerOnSameMatch_StaysJoker()
+        {
+            var targetMatch = new Match { Id = "m1", StartTime = DateTime.UtcNow.AddHours(1) };
+            var match = new Match { Id = "m1", Stage = TournamentStage.Group, StartTime = DateTime.UtcNow.AddHours(1), Round = 1 };
+            var bet = new MatchBet { Id = "b1", Match = targetMatch, IsJoker = true };
+            var roundBets = new List<MatchBet> { bet };
+
+            this.mockDb.Setup(d => d.GetMatchById("m1")).Returns(match);
+            this.mockDb.Setup(d => d.GetBetsForUserAndRound("test-user", 1)).Returns(roundBets);
+
+            var sut = this.CreateSut();
+            var result = sut.SetJoker("m1");
+
+            Assert.IsType<OkResult>(result);
+            Assert.True(bet.IsJoker);
+        }
+
+        #endregion
+
+        #region Round independence: joker on round 1 doesn't affect round 2
+
+        [Fact]
+        public void SetJoker_DifferentRoundsAreIndependent()
+        {
+            // Set joker on round 2 — round 1 joker should be unaffected
+            var targetMatch = new Match { Id = "m3" };
+            var match = new Match { Id = "m3", Stage = TournamentStage.Group, StartTime = DateTime.UtcNow.AddHours(1), Round = 2 };
+            var round2Bet = new MatchBet { Id = "b3", Match = targetMatch, IsJoker = false };
+            var round2Bets = new List<MatchBet> { round2Bet };
+
+            // Round 1 has its own joker — not returned by GetBetsForUserAndRound(round=2)
+            this.mockDb.Setup(d => d.GetMatchById("m3")).Returns(match);
+            this.mockDb.Setup(d => d.GetBetsForUserAndRound("test-user", 2)).Returns(round2Bets);
+
+            var sut = this.CreateSut();
+            var result = sut.SetJoker("m3");
+
+            Assert.IsType<OkResult>(result);
+            Assert.True(round2Bet.IsJoker);
+
+            // Verify only round 2 bets were updated
+            this.mockDb.Verify(d => d.UpdateBets(round2Bets), Times.Once);
+            this.mockDb.Verify(d => d.GetBetsForUserAndRound("test-user", 1), Times.Never);
+        }
+
+        #endregion
+
+        #region Multiple bets in same round: only target gets joker
+
+        [Fact]
+        public void SetJoker_MultipleRoundBets_OnlyTargetGetsJoker()
+        {
+            var targetMatch = new Match { Id = "m1" };
+            var otherMatch1 = new Match { Id = "m2" };
+            var otherMatch2 = new Match { Id = "m3" };
+            var match = new Match { Id = "m1", Stage = TournamentStage.Group, StartTime = DateTime.UtcNow.AddHours(1), Round = 1 };
+
+            var targetBet = new MatchBet { Id = "b1", Match = targetMatch, IsJoker = false };
+            var otherBet1 = new MatchBet { Id = "b2", Match = otherMatch1, IsJoker = false };
+            var otherBet2 = new MatchBet { Id = "b3", Match = otherMatch2, IsJoker = false };
+            var roundBets = new List<MatchBet> { targetBet, otherBet1, otherBet2 };
+
+            this.mockDb.Setup(d => d.GetMatchById("m1")).Returns(match);
+            this.mockDb.Setup(d => d.GetBetsForUserAndRound("test-user", 1)).Returns(roundBets);
+
+            var sut = this.CreateSut();
+            var result = sut.SetJoker("m1");
+
+            Assert.IsType<OkResult>(result);
+            Assert.True(targetBet.IsJoker);
+            Assert.False(otherBet1.IsJoker);
+            Assert.False(otherBet2.IsJoker);
+        }
+
+        [Fact]
+        public void SetJoker_SwitchFromOneMatchToAnother_InSameRound()
+        {
+            // Joker is on m2, user wants to move it to m1
+            var targetMatch = new Match { Id = "m1" };
+            var otherMatch = new Match { Id = "m2", StartTime = DateTime.UtcNow.AddHours(2) };
+            var match = new Match { Id = "m1", Stage = TournamentStage.Group, StartTime = DateTime.UtcNow.AddHours(1), Round = 1 };
+
+            var targetBet = new MatchBet { Id = "b1", Match = targetMatch, IsJoker = false };
+            var previousJokerBet = new MatchBet { Id = "b2", Match = otherMatch, IsJoker = true };
+            var roundBets = new List<MatchBet> { targetBet, previousJokerBet };
+
+            this.mockDb.Setup(d => d.GetMatchById("m1")).Returns(match);
+            this.mockDb.Setup(d => d.GetBetsForUserAndRound("test-user", 1)).Returns(roundBets);
+
+            var sut = this.CreateSut();
+            var result = sut.SetJoker("m1");
+
+            Assert.IsType<OkResult>(result);
+            Assert.True(targetBet.IsJoker);
+            Assert.False(previousJokerBet.IsJoker);
+
+            // Exactly one joker in round
+            Assert.Equal(1, roundBets.Count(b => b.IsJoker));
+        }
+
+        #endregion
+
+        #region Constraint: exactly 1 joker per round after SetJoker
+
+        [Fact]
+        public void SetJoker_AlwaysResultsInExactlyOneJokerInRound()
+        {
+            var targetMatch = new Match { Id = "m1" };
+            var otherMatch1 = new Match { Id = "m2", StartTime = DateTime.UtcNow.AddHours(2) };
+            var otherMatch2 = new Match { Id = "m3", StartTime = DateTime.UtcNow.AddHours(3) };
+            var match = new Match { Id = "m1", Stage = TournamentStage.Group, StartTime = DateTime.UtcNow.AddHours(1), Round = 1 };
+
+            // Simulate a corrupted state: 2 jokers somehow exist in round
+            var targetBet = new MatchBet { Id = "b1", Match = targetMatch, IsJoker = false };
+            var badJoker1 = new MatchBet { Id = "b2", Match = otherMatch1, IsJoker = true };
+            var badJoker2 = new MatchBet { Id = "b3", Match = otherMatch2, IsJoker = true };
+            var roundBets = new List<MatchBet> { targetBet, badJoker1, badJoker2 };
+
+            this.mockDb.Setup(d => d.GetMatchById("m1")).Returns(match);
+            this.mockDb.Setup(d => d.GetBetsForUserAndRound("test-user", 1)).Returns(roundBets);
+
+            var sut = this.CreateSut();
+            var result = sut.SetJoker("m1");
+
+            Assert.IsType<OkResult>(result);
+
+            // All cleared, only target is joker
+            Assert.True(targetBet.IsJoker);
+            Assert.False(badJoker1.IsJoker);
+            Assert.False(badJoker2.IsJoker);
+            Assert.Equal(1, roundBets.Count(b => b.IsJoker));
+        }
+
+        #endregion
+
+        #region Round=0 edge case
+
+        [Fact]
+        public void SetJoker_MatchWithRound0_StillWorksIfBetExists()
+        {
+            // Round=0 is the default for matches without a round set.
+            // SetJoker should still work — it fetches bets for round 0.
+            var targetMatch = new Match { Id = "m1" };
+            var match = new Match { Id = "m1", Stage = TournamentStage.Group, StartTime = DateTime.UtcNow.AddHours(1), Round = 0 };
+            var bet = new MatchBet { Id = "b1", Match = targetMatch, IsJoker = false };
+            var roundBets = new List<MatchBet> { bet };
+
+            this.mockDb.Setup(d => d.GetMatchById("m1")).Returns(match);
+            this.mockDb.Setup(d => d.GetBetsForUserAndRound("test-user", 0)).Returns(roundBets);
+
+            var sut = this.CreateSut();
+            var result = sut.SetJoker("m1");
+
+            Assert.IsType<OkResult>(result);
+            Assert.True(bet.IsJoker);
+        }
+
+        #endregion
+
+        #region Joker locked when existing joker match already started
+
+        [Fact]
+        public void SetJoker_ExistingJokerOnStartedMatch_ReturnsBadRequest()
+        {
+            // Joker is on m2 which already started. User tries to move joker to m1 (not started).
+            // This must be rejected — the round's joker is locked.
+            var targetMatch = new Match { Id = "m1" };
+            var startedMatch = new Match { Id = "m2", StartTime = DateTime.UtcNow.AddHours(-1) };
+            var match = new Match { Id = "m1", Stage = TournamentStage.Group, StartTime = DateTime.UtcNow.AddHours(1), Round = 1 };
+
+            var targetBet = new MatchBet { Id = "b1", Match = targetMatch, IsJoker = false };
+            var lockedJokerBet = new MatchBet { Id = "b2", Match = startedMatch, IsJoker = true };
+            var roundBets = new List<MatchBet> { targetBet, lockedJokerBet };
+
+            this.mockDb.Setup(d => d.GetMatchById("m1")).Returns(match);
+            this.mockDb.Setup(d => d.GetBetsForUserAndRound("test-user", 1)).Returns(roundBets);
+
+            var sut = this.CreateSut();
+            var result = sut.SetJoker("m1");
+
+            Assert.IsType<BadRequestObjectResult>(result);
+            // Joker should not have changed
+            Assert.False(targetBet.IsJoker);
+            Assert.True(lockedJokerBet.IsJoker);
+            this.mockDb.Verify(d => d.UpdateBets(It.IsAny<List<MatchBet>>()), Times.Never);
+        }
+
+        [Fact]
+        public void SetJoker_ExistingJokerOnNotStartedMatch_CanSwitch()
+        {
+            // Joker is on m2 which has NOT started. User can move joker to m1.
+            var targetMatch = new Match { Id = "m1" };
+            var notStartedMatch = new Match { Id = "m2", StartTime = DateTime.UtcNow.AddHours(2) };
+            var match = new Match { Id = "m1", Stage = TournamentStage.Group, StartTime = DateTime.UtcNow.AddHours(1), Round = 1 };
+
+            var targetBet = new MatchBet { Id = "b1", Match = targetMatch, IsJoker = false };
+            var previousJokerBet = new MatchBet { Id = "b2", Match = notStartedMatch, IsJoker = true };
+            var roundBets = new List<MatchBet> { targetBet, previousJokerBet };
+
+            this.mockDb.Setup(d => d.GetMatchById("m1")).Returns(match);
+            this.mockDb.Setup(d => d.GetBetsForUserAndRound("test-user", 1)).Returns(roundBets);
+
+            var sut = this.CreateSut();
+            var result = sut.SetJoker("m1");
+
+            Assert.IsType<OkResult>(result);
+            Assert.True(targetBet.IsJoker);
+            Assert.False(previousJokerBet.IsJoker);
+        }
+
+        #endregion
+    }
+}

--- a/TipTournament2.0.Tests/Coordinator/GroupMatchesResultCoordinatorJokerTests.cs
+++ b/TipTournament2.0.Tests/Coordinator/GroupMatchesResultCoordinatorJokerTests.cs
@@ -1,0 +1,531 @@
+namespace TipTournament2._0.Tests.Coordinator
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Moq;
+    using TipTournament2._0.Calculator;
+    using TipTournament2._0.Coordinator;
+    using TipTournament2._0.Data;
+    using TipTournament2._0.MatchClient;
+    using TipTournament2._0.Models;
+    using Xunit;
+    using Match = TipTournament2._0.Models.Match;
+
+    public class GroupMatchesResultCoordinatorJokerTests
+    {
+        private readonly Mock<IMatchClient> mockMatchClient = new Mock<IMatchClient>();
+        private readonly Mock<IDbContextWrapper> mockDb = new Mock<IDbContextWrapper>();
+        private readonly Mock<IBetResultMaker> mockBetMaker = new Mock<IBetResultMaker>();
+
+        private void SetupCommon(Result result, out Result savedResult, out Match match)
+        {
+            savedResult = new Result { Id = "r1", HomeTeam = result.HomeTeam, AwayTeam = result.AwayTeam };
+            match = new Match { Id = "m1" };
+
+            this.mockDb.Setup(d => d.SaveResult(result)).Returns(savedResult);
+            this.mockDb.Setup(d => d.GetMatchById("m1")).Returns(match);
+            this.mockDb.Setup(d => d.GetBetsForMatch(It.IsAny<Match>())).Returns(new List<MatchBet>());
+            this.mockBetMaker.Setup(b => b.UpdateBetResult(It.IsAny<List<MatchBet>>(), It.IsAny<Result>())).Returns(new List<MatchBet>());
+        }
+
+        #region Joker doubles base points for each BetResult level
+
+        [Theory]
+        [InlineData(BetResult.WINNER, 2)]     // 1 * 2 = 2
+        [InlineData(BetResult.DIFFERENCE, 4)]  // 2 * 2 = 4
+        [InlineData(BetResult.SCORE, 8)]       // 4 * 2 = 8
+        public void Joker_CorrectBet_DoublesBasePoints(BetResult betResult, int expectedPoints)
+        {
+            var result = new Result { HomeTeam = 2, AwayTeam = 1 };
+            this.SetupCommon(result, out var savedResult, out var match);
+
+            var user = new ApplicationUser { Id = "u1", AlfaPoints = 0, TotalPoints = 0 };
+            var bet = new MatchBet { Result = betResult, IsJoker = true, DixitBonus = 0 };
+
+            this.mockDb.Setup(d => d.GetAllUsers()).Returns(new List<ApplicationUser> { user });
+            this.mockDb.Setup(d => d.GetBetForMatchAndUser(match, "u1")).Returns(bet);
+
+            var sut = new GroupMatchesResultCoordinator(this.mockMatchClient.Object, this.mockDb.Object, this.mockBetMaker.Object);
+            sut.UploadNewResult("m1", result);
+
+            Assert.Equal(expectedPoints, user.AlfaPoints);
+            Assert.Equal(expectedPoints, user.TotalPoints);
+        }
+
+        #endregion
+
+        #region Joker wrong bet = zero points (no negative penalty)
+
+        [Fact]
+        public void Joker_WrongBet_GetsZeroPoints()
+        {
+            var result = new Result { HomeTeam = 2, AwayTeam = 1 };
+            this.SetupCommon(result, out var savedResult, out var match);
+
+            var user = new ApplicationUser { Id = "u1", AlfaPoints = 0, TotalPoints = 0 };
+            var bet = new MatchBet { Result = BetResult.NOTHING, IsJoker = true, DixitBonus = 0 };
+
+            this.mockDb.Setup(d => d.GetAllUsers()).Returns(new List<ApplicationUser> { user });
+            this.mockDb.Setup(d => d.GetBetForMatchAndUser(match, "u1")).Returns(bet);
+
+            var sut = new GroupMatchesResultCoordinator(this.mockMatchClient.Object, this.mockDb.Object, this.mockBetMaker.Object);
+            sut.UploadNewResult("m1", result);
+
+            Assert.Equal(0, user.AlfaPoints);
+            Assert.Equal(0, user.TotalPoints);
+        }
+
+        [Fact]
+        public void Joker_WrongBet_DoesNotAffectPreExistingPoints()
+        {
+            var result = new Result { HomeTeam = 2, AwayTeam = 1 };
+            this.SetupCommon(result, out var savedResult, out var match);
+
+            var user = new ApplicationUser { Id = "u1", AlfaPoints = 10, TotalPoints = 25 };
+            var bet = new MatchBet { Result = BetResult.NOTHING, IsJoker = true, DixitBonus = 0 };
+
+            this.mockDb.Setup(d => d.GetAllUsers()).Returns(new List<ApplicationUser> { user });
+            this.mockDb.Setup(d => d.GetBetForMatchAndUser(match, "u1")).Returns(bet);
+
+            var sut = new GroupMatchesResultCoordinator(this.mockMatchClient.Object, this.mockDb.Object, this.mockBetMaker.Object);
+            sut.UploadNewResult("m1", result);
+
+            // Points unchanged — wrong joker adds 0, not negative
+            Assert.Equal(10, user.AlfaPoints);
+            Assert.Equal(25, user.TotalPoints);
+        }
+
+        #endregion
+
+        #region Joker + DixitBonus interaction: only base points doubled, dixit added separately
+
+        [Fact]
+        public void Joker_WithDixitBonus_OnlyBaseDoubled_DixitAddedSeparately()
+        {
+            var result = new Result { HomeTeam = 2, AwayTeam = 1 };
+            this.SetupCommon(result, out var savedResult, out var match);
+
+            var user = new ApplicationUser { Id = "u1", AlfaPoints = 0, TotalPoints = 0 };
+            // WINNER=1, Joker doubles to 2, DixitBonus=3 added on top → 5
+            var bet = new MatchBet { Result = BetResult.WINNER, IsJoker = true, DixitBonus = 3 };
+
+            this.mockDb.Setup(d => d.GetAllUsers()).Returns(new List<ApplicationUser> { user });
+            this.mockDb.Setup(d => d.GetBetForMatchAndUser(match, "u1")).Returns(bet);
+
+            var sut = new GroupMatchesResultCoordinator(this.mockMatchClient.Object, this.mockDb.Object, this.mockBetMaker.Object);
+            sut.UploadNewResult("m1", result);
+
+            Assert.Equal(5, user.AlfaPoints);   // (1 * 2) + 3 = 5
+            Assert.Equal(5, user.TotalPoints);
+        }
+
+        [Fact]
+        public void Joker_Difference_WithDixitBonus2_Gets6Points()
+        {
+            var result = new Result { HomeTeam = 2, AwayTeam = 1 };
+            this.SetupCommon(result, out var savedResult, out var match);
+
+            var user = new ApplicationUser { Id = "u1", AlfaPoints = 0, TotalPoints = 0 };
+            // DIFFERENCE=2, Joker doubles to 4, DixitBonus=2 → 6
+            var bet = new MatchBet { Result = BetResult.DIFFERENCE, IsJoker = true, DixitBonus = 2 };
+
+            this.mockDb.Setup(d => d.GetAllUsers()).Returns(new List<ApplicationUser> { user });
+            this.mockDb.Setup(d => d.GetBetForMatchAndUser(match, "u1")).Returns(bet);
+
+            var sut = new GroupMatchesResultCoordinator(this.mockMatchClient.Object, this.mockDb.Object, this.mockBetMaker.Object);
+            sut.UploadNewResult("m1", result);
+
+            Assert.Equal(6, user.AlfaPoints);   // (2 * 2) + 2 = 6
+            Assert.Equal(6, user.TotalPoints);
+        }
+
+        [Fact]
+        public void Joker_Score_WithDixitBonus_FullCalculation()
+        {
+            var result = new Result { HomeTeam = 2, AwayTeam = 1 };
+            this.SetupCommon(result, out var savedResult, out var match);
+
+            var user = new ApplicationUser { Id = "u1", AlfaPoints = 0, TotalPoints = 0 };
+            // SCORE=4, Joker doubles to 8, DixitBonus=2 → 10
+            var bet = new MatchBet { Result = BetResult.SCORE, IsJoker = true, DixitBonus = 2 };
+
+            this.mockDb.Setup(d => d.GetAllUsers()).Returns(new List<ApplicationUser> { user });
+            this.mockDb.Setup(d => d.GetBetForMatchAndUser(match, "u1")).Returns(bet);
+
+            var sut = new GroupMatchesResultCoordinator(this.mockMatchClient.Object, this.mockDb.Object, this.mockBetMaker.Object);
+            sut.UploadNewResult("m1", result);
+
+            Assert.Equal(10, user.AlfaPoints);   // (4 * 2) + 2 = 10
+            Assert.Equal(10, user.TotalPoints);
+        }
+
+        [Fact]
+        public void Joker_Score_WithMaxDixitBonus3_Gets11Points()
+        {
+            // Maximum possible from a single bet: SCORE Joker + max Dixit = (4*2) + 3 = 11
+            var result = new Result { HomeTeam = 2, AwayTeam = 1 };
+            this.SetupCommon(result, out var savedResult, out var match);
+
+            var user = new ApplicationUser { Id = "u1", AlfaPoints = 0, TotalPoints = 0 };
+            var bet = new MatchBet { Result = BetResult.SCORE, IsJoker = true, DixitBonus = 3 };
+
+            this.mockDb.Setup(d => d.GetAllUsers()).Returns(new List<ApplicationUser> { user });
+            this.mockDb.Setup(d => d.GetBetForMatchAndUser(match, "u1")).Returns(bet);
+
+            var sut = new GroupMatchesResultCoordinator(this.mockMatchClient.Object, this.mockDb.Object, this.mockBetMaker.Object);
+            sut.UploadNewResult("m1", result);
+
+            Assert.Equal(11, user.AlfaPoints);   // (4 * 2) + 3 = 11
+            Assert.Equal(11, user.TotalPoints);
+        }
+
+        #endregion
+
+        #region Non-joker bets are not affected (backward compatibility)
+
+        [Fact]
+        public void NonJoker_CorrectBet_NormalScoring()
+        {
+            var result = new Result { HomeTeam = 2, AwayTeam = 1 };
+            this.SetupCommon(result, out var savedResult, out var match);
+
+            var user = new ApplicationUser { Id = "u1", AlfaPoints = 0, TotalPoints = 0 };
+            var bet = new MatchBet { Result = BetResult.SCORE, IsJoker = false, DixitBonus = 0 };
+
+            this.mockDb.Setup(d => d.GetAllUsers()).Returns(new List<ApplicationUser> { user });
+            this.mockDb.Setup(d => d.GetBetForMatchAndUser(match, "u1")).Returns(bet);
+
+            var sut = new GroupMatchesResultCoordinator(this.mockMatchClient.Object, this.mockDb.Object, this.mockBetMaker.Object);
+            sut.UploadNewResult("m1", result);
+
+            Assert.Equal(4, user.AlfaPoints);
+            Assert.Equal(4, user.TotalPoints);
+        }
+
+        [Fact]
+        public void NonJoker_WithDixitBonus_NormalScoring()
+        {
+            // Existing behavior preserved: non-joker WINNER + Dixit=2 → 1+2=3
+            var result = new Result { HomeTeam = 2, AwayTeam = 1 };
+            this.SetupCommon(result, out var savedResult, out var match);
+
+            var user = new ApplicationUser { Id = "u1", AlfaPoints = 0, TotalPoints = 0 };
+            var bet = new MatchBet { Result = BetResult.WINNER, IsJoker = false, DixitBonus = 2 };
+
+            this.mockDb.Setup(d => d.GetAllUsers()).Returns(new List<ApplicationUser> { user });
+            this.mockDb.Setup(d => d.GetBetForMatchAndUser(match, "u1")).Returns(bet);
+
+            var sut = new GroupMatchesResultCoordinator(this.mockMatchClient.Object, this.mockDb.Object, this.mockBetMaker.Object);
+            sut.UploadNewResult("m1", result);
+
+            Assert.Equal(3, user.AlfaPoints);   // (1 * 1) + 2 = 3
+            Assert.Equal(3, user.TotalPoints);
+        }
+
+        [Fact]
+        public void NonJoker_WrongBet_ZeroPoints()
+        {
+            var result = new Result { HomeTeam = 2, AwayTeam = 1 };
+            this.SetupCommon(result, out var savedResult, out var match);
+
+            var user = new ApplicationUser { Id = "u1", AlfaPoints = 5, TotalPoints = 15 };
+            var bet = new MatchBet { Result = BetResult.NOTHING, IsJoker = false, DixitBonus = 0 };
+
+            this.mockDb.Setup(d => d.GetAllUsers()).Returns(new List<ApplicationUser> { user });
+            this.mockDb.Setup(d => d.GetBetForMatchAndUser(match, "u1")).Returns(bet);
+
+            var sut = new GroupMatchesResultCoordinator(this.mockMatchClient.Object, this.mockDb.Object, this.mockBetMaker.Object);
+            sut.UploadNewResult("m1", result);
+
+            Assert.Equal(5, user.AlfaPoints);
+            Assert.Equal(15, user.TotalPoints);
+        }
+
+        [Fact]
+        public void IsJoker_DefaultsFalse_OldBetsUnaffected()
+        {
+            // Simulates old bets from DB that were created before IsJoker existed.
+            // bool defaults to false, so old bets should score normally.
+            var result = new Result { HomeTeam = 2, AwayTeam = 1 };
+            this.SetupCommon(result, out var savedResult, out var match);
+
+            var user = new ApplicationUser { Id = "u1", AlfaPoints = 0, TotalPoints = 0 };
+            var bet = new MatchBet { Result = BetResult.SCORE, DixitBonus = 1 };
+            // IsJoker not set — defaults to false
+
+            this.mockDb.Setup(d => d.GetAllUsers()).Returns(new List<ApplicationUser> { user });
+            this.mockDb.Setup(d => d.GetBetForMatchAndUser(match, "u1")).Returns(bet);
+
+            var sut = new GroupMatchesResultCoordinator(this.mockMatchClient.Object, this.mockDb.Object, this.mockBetMaker.Object);
+            sut.UploadNewResult("m1", result);
+
+            Assert.Equal(5, user.AlfaPoints);   // 4 + 1 (no doubling)
+            Assert.Equal(5, user.TotalPoints);
+        }
+
+        #endregion
+
+        #region Multiple users: joker vs non-joker scoring in same match
+
+        [Fact]
+        public void MultipleUsers_JokerAndNonJoker_CorrectPointsForEach()
+        {
+            var result = new Result { HomeTeam = 2, AwayTeam = 1 };
+            this.SetupCommon(result, out var savedResult, out var match);
+
+            var userWithJoker = new ApplicationUser { Id = "u1", AlfaPoints = 0, TotalPoints = 0 };
+            var userWithoutJoker = new ApplicationUser { Id = "u2", AlfaPoints = 0, TotalPoints = 0 };
+            var userWrongJoker = new ApplicationUser { Id = "u3", AlfaPoints = 0, TotalPoints = 0 };
+
+            var betJoker = new MatchBet { Result = BetResult.SCORE, IsJoker = true, DixitBonus = 0 };
+            var betNormal = new MatchBet { Result = BetResult.SCORE, IsJoker = false, DixitBonus = 0 };
+            var betWrongJoker = new MatchBet { Result = BetResult.NOTHING, IsJoker = true, DixitBonus = 0 };
+
+            this.mockDb.Setup(d => d.GetAllUsers()).Returns(new List<ApplicationUser> { userWithJoker, userWithoutJoker, userWrongJoker });
+            this.mockDb.Setup(d => d.GetBetForMatchAndUser(match, "u1")).Returns(betJoker);
+            this.mockDb.Setup(d => d.GetBetForMatchAndUser(match, "u2")).Returns(betNormal);
+            this.mockDb.Setup(d => d.GetBetForMatchAndUser(match, "u3")).Returns(betWrongJoker);
+
+            var sut = new GroupMatchesResultCoordinator(this.mockMatchClient.Object, this.mockDb.Object, this.mockBetMaker.Object);
+            sut.UploadNewResult("m1", result);
+
+            Assert.Equal(8, userWithJoker.AlfaPoints);      // SCORE(4) * 2 = 8
+            Assert.Equal(4, userWithoutJoker.AlfaPoints);    // SCORE(4) * 1 = 4
+            Assert.Equal(0, userWrongJoker.AlfaPoints);      // NOTHING = 0 (joker doesn't help)
+        }
+
+        [Fact]
+        public void MultipleUsers_JokerWithDixit_NonJokerWithDixit_CorrectTotals()
+        {
+            var result = new Result { HomeTeam = 2, AwayTeam = 1 };
+            this.SetupCommon(result, out var savedResult, out var match);
+
+            var userJoker = new ApplicationUser { Id = "u1", AlfaPoints = 10, TotalPoints = 20 };
+            var userNormal = new ApplicationUser { Id = "u2", AlfaPoints = 5, TotalPoints = 15 };
+
+            var betJoker = new MatchBet { Result = BetResult.WINNER, IsJoker = true, DixitBonus = 2 };
+            var betNormal = new MatchBet { Result = BetResult.WINNER, IsJoker = false, DixitBonus = 2 };
+
+            this.mockDb.Setup(d => d.GetAllUsers()).Returns(new List<ApplicationUser> { userJoker, userNormal });
+            this.mockDb.Setup(d => d.GetBetForMatchAndUser(match, "u1")).Returns(betJoker);
+            this.mockDb.Setup(d => d.GetBetForMatchAndUser(match, "u2")).Returns(betNormal);
+
+            var sut = new GroupMatchesResultCoordinator(this.mockMatchClient.Object, this.mockDb.Object, this.mockBetMaker.Object);
+            sut.UploadNewResult("m1", result);
+
+            // userJoker: (1*2) + 2 = 4 added
+            Assert.Equal(14, userJoker.AlfaPoints);
+            Assert.Equal(24, userJoker.TotalPoints);
+
+            // userNormal: (1*1) + 2 = 3 added
+            Assert.Equal(8, userNormal.AlfaPoints);
+            Assert.Equal(18, userNormal.TotalPoints);
+        }
+
+        #endregion
+
+        #region Accumulation: Joker points add to existing user points correctly
+
+        [Fact]
+        public void Joker_AccumulatesOnExistingPoints()
+        {
+            var result = new Result { HomeTeam = 2, AwayTeam = 1 };
+            this.SetupCommon(result, out var savedResult, out var match);
+
+            // User has existing points from previous matches
+            var user = new ApplicationUser { Id = "u1", AlfaPoints = 15, TotalPoints = 42 };
+            var bet = new MatchBet { Result = BetResult.DIFFERENCE, IsJoker = true, DixitBonus = 1 };
+
+            this.mockDb.Setup(d => d.GetAllUsers()).Returns(new List<ApplicationUser> { user });
+            this.mockDb.Setup(d => d.GetBetForMatchAndUser(match, "u1")).Returns(bet);
+
+            var sut = new GroupMatchesResultCoordinator(this.mockMatchClient.Object, this.mockDb.Object, this.mockBetMaker.Object);
+            sut.UploadNewResult("m1", result);
+
+            // (2*2) + 1 = 5 added
+            Assert.Equal(20, user.AlfaPoints);   // 15 + 5
+            Assert.Equal(47, user.TotalPoints);  // 42 + 5
+        }
+
+        #endregion
+
+        #region End-to-end: DixitBonus computed then Joker applied
+
+        [Fact]
+        public void EndToEnd_JokerBet_WithDixitBonusComputed_FullPipeline()
+        {
+            // Full pipeline: BetResultMaker → DixitBonusCalculator → RecalculatePoints with Joker
+            // 1 correct out of 2 total → Dixit bonus = 3 (only 1 correct)
+            var result = new Result { HomeTeam = 2, AwayTeam = 1 };
+            var savedResult = new Result { Id = "r1", HomeTeam = 2, AwayTeam = 1 };
+            var match = new Match { Id = "m1" };
+
+            var userA = new ApplicationUser { Id = "uA", AlfaPoints = 0, TotalPoints = 0 };
+            var userB = new ApplicationUser { Id = "uB", AlfaPoints = 0, TotalPoints = 0 };
+
+            var betA = new MatchBet { Result = BetResult.NOTHING, IsJoker = false };
+            var betB = new MatchBet { Result = BetResult.NOTHING, IsJoker = true };  // Joker bet
+            var allBets = new List<MatchBet> { betA, betB };
+
+            this.mockBetMaker.Setup(b => b.UpdateBetResult(allBets, savedResult))
+                .Callback<List<MatchBet>, Result>((bets, r) =>
+                {
+                    bets[0].Result = BetResult.NOTHING;   // userA wrong
+                    bets[1].Result = BetResult.WINNER;     // userB correct
+                })
+                .Returns(allBets);
+
+            this.mockDb.Setup(d => d.SaveResult(result)).Returns(savedResult);
+            this.mockDb.Setup(d => d.GetMatchById("m1")).Returns(match);
+            this.mockDb.Setup(d => d.GetBetsForMatch(It.IsAny<Match>())).Returns(allBets);
+            this.mockDb.Setup(d => d.GetAllUsers()).Returns(new List<ApplicationUser> { userA, userB });
+            this.mockDb.Setup(d => d.GetBetForMatchAndUser(match, "uA")).Returns(betA);
+            this.mockDb.Setup(d => d.GetBetForMatchAndUser(match, "uB")).Returns(betB);
+
+            var sut = new GroupMatchesResultCoordinator(this.mockMatchClient.Object, this.mockDb.Object, this.mockBetMaker.Object);
+            sut.UploadNewResult("m1", result);
+
+            // DixitBonusCalculator should give betB DixitBonus=3 (only 1 of 2 correct)
+            Assert.Equal(3, betB.DixitBonus);
+
+            // userA: wrong bet, no points
+            Assert.Equal(0, userA.AlfaPoints);
+            Assert.Equal(0, userA.TotalPoints);
+
+            // userB: (WINNER=1 * Joker=2) + DixitBonus=3 = 5
+            Assert.Equal(5, userB.AlfaPoints);
+            Assert.Equal(5, userB.TotalPoints);
+        }
+
+        [Fact]
+        public void EndToEnd_JokerBet_NoDixitBonus_WhenManyCorrect()
+        {
+            // 8 out of 10 correct → 80% → no Dixit bonus. Joker still doubles base.
+            var result = new Result { HomeTeam = 1, AwayTeam = 0 };
+            var savedResult = new Result { Id = "r1", HomeTeam = 1, AwayTeam = 0 };
+            var match = new Match { Id = "m1" };
+
+            var allBets = new List<MatchBet>();
+            var users = new List<ApplicationUser>();
+            for (int i = 0; i < 10; i++)
+            {
+                allBets.Add(new MatchBet { Result = BetResult.NOTHING, IsJoker = i == 0 }); // first bet is Joker
+                users.Add(new ApplicationUser { Id = $"u{i}", AlfaPoints = 0, TotalPoints = 0 });
+            }
+
+            this.mockBetMaker.Setup(b => b.UpdateBetResult(allBets, savedResult))
+                .Callback<List<MatchBet>, Result>((bets, r) =>
+                {
+                    for (int i = 0; i < 8; i++) bets[i].Result = BetResult.WINNER;
+                    // bets[8] and bets[9] stay NOTHING
+                })
+                .Returns(allBets);
+
+            this.mockDb.Setup(d => d.SaveResult(result)).Returns(savedResult);
+            this.mockDb.Setup(d => d.GetMatchById("m1")).Returns(match);
+            this.mockDb.Setup(d => d.GetBetsForMatch(It.IsAny<Match>())).Returns(allBets);
+            this.mockDb.Setup(d => d.GetAllUsers()).Returns(users);
+            for (int i = 0; i < 10; i++)
+            {
+                var idx = i;
+                this.mockDb.Setup(d => d.GetBetForMatchAndUser(match, $"u{idx}")).Returns(allBets[idx]);
+            }
+
+            var sut = new GroupMatchesResultCoordinator(this.mockMatchClient.Object, this.mockDb.Object, this.mockBetMaker.Object);
+            sut.UploadNewResult("m1", result);
+
+            // 80% correct → 0 Dixit bonus for all
+            Assert.All(allBets, b => Assert.Equal(0, b.DixitBonus));
+
+            // User 0: Joker + WINNER → (1*2)+0 = 2
+            Assert.Equal(2, users[0].AlfaPoints);
+            Assert.Equal(2, users[0].TotalPoints);
+
+            // Users 1-7: non-Joker + WINNER → (1*1)+0 = 1
+            for (int i = 1; i < 8; i++)
+            {
+                Assert.Equal(1, users[i].AlfaPoints);
+                Assert.Equal(1, users[i].TotalPoints);
+            }
+
+            // Users 8-9: NOTHING → 0
+            Assert.Equal(0, users[8].AlfaPoints);
+            Assert.Equal(0, users[9].AlfaPoints);
+        }
+
+        [Fact]
+        public void EndToEnd_JokerWrongBet_WithDixitBonusComputedForOthers()
+        {
+            // User has Joker but bet is wrong. DixitBonus computed but irrelevant since NOTHING.
+            // Actually, DixitBonusCalculator sets DixitBonus=0 for NOTHING bets.
+            var result = new Result { HomeTeam = 2, AwayTeam = 1 };
+            var savedResult = new Result { Id = "r1", HomeTeam = 2, AwayTeam = 1 };
+            var match = new Match { Id = "m1" };
+
+            var userJoker = new ApplicationUser { Id = "uJ", AlfaPoints = 10, TotalPoints = 30 };
+            var userCorrect = new ApplicationUser { Id = "uC", AlfaPoints = 5, TotalPoints = 20 };
+
+            var betJokerWrong = new MatchBet { Result = BetResult.NOTHING, IsJoker = true };
+            var betCorrect = new MatchBet { Result = BetResult.NOTHING, IsJoker = false };
+            var allBets = new List<MatchBet> { betJokerWrong, betCorrect };
+
+            this.mockBetMaker.Setup(b => b.UpdateBetResult(allBets, savedResult))
+                .Callback<List<MatchBet>, Result>((bets, r) =>
+                {
+                    bets[0].Result = BetResult.NOTHING;  // Joker user is wrong
+                    bets[1].Result = BetResult.SCORE;     // Other user is correct
+                })
+                .Returns(allBets);
+
+            this.mockDb.Setup(d => d.SaveResult(result)).Returns(savedResult);
+            this.mockDb.Setup(d => d.GetMatchById("m1")).Returns(match);
+            this.mockDb.Setup(d => d.GetBetsForMatch(It.IsAny<Match>())).Returns(allBets);
+            this.mockDb.Setup(d => d.GetAllUsers()).Returns(new List<ApplicationUser> { userJoker, userCorrect });
+            this.mockDb.Setup(d => d.GetBetForMatchAndUser(match, "uJ")).Returns(betJokerWrong);
+            this.mockDb.Setup(d => d.GetBetForMatchAndUser(match, "uC")).Returns(betCorrect);
+
+            var sut = new GroupMatchesResultCoordinator(this.mockMatchClient.Object, this.mockDb.Object, this.mockBetMaker.Object);
+            sut.UploadNewResult("m1", result);
+
+            // Joker wrong bet: DixitBonus=0 (DixitBonusCalculator sets 0 for NOTHING), points = (0*2)+0 = 0
+            Assert.Equal(0, betJokerWrong.DixitBonus);
+            Assert.Equal(10, userJoker.AlfaPoints);    // unchanged
+            Assert.Equal(30, userJoker.TotalPoints);   // unchanged
+
+            // Correct bet: 1 of 2 correct → DixitBonus=3, points = (4*1)+3 = 7
+            Assert.Equal(3, betCorrect.DixitBonus);
+            Assert.Equal(12, userCorrect.AlfaPoints);  // 5 + 7
+            Assert.Equal(27, userCorrect.TotalPoints); // 20 + 7
+        }
+
+        #endregion
+
+        #region AlfaPoints and TotalPoints always stay in sync
+
+        [Fact]
+        public void Joker_BothAlfaAndTotalPointsUpdatedIdentically()
+        {
+            var result = new Result { HomeTeam = 2, AwayTeam = 1 };
+            this.SetupCommon(result, out var savedResult, out var match);
+
+            // User has different Alfa and Total (other stages contributed to Total)
+            var user = new ApplicationUser { Id = "u1", AlfaPoints = 5, TotalPoints = 30 };
+            var bet = new MatchBet { Result = BetResult.SCORE, IsJoker = true, DixitBonus = 1 };
+
+            this.mockDb.Setup(d => d.GetAllUsers()).Returns(new List<ApplicationUser> { user });
+            this.mockDb.Setup(d => d.GetBetForMatchAndUser(match, "u1")).Returns(bet);
+
+            var sut = new GroupMatchesResultCoordinator(this.mockMatchClient.Object, this.mockDb.Object, this.mockBetMaker.Object);
+            sut.UploadNewResult("m1", result);
+
+            // (4*2)+1 = 9 added to BOTH
+            Assert.Equal(14, user.AlfaPoints);   // 5 + 9
+            Assert.Equal(39, user.TotalPoints);  // 30 + 9
+
+            // Delta between Alfa and Total unchanged
+            Assert.Equal(25, user.TotalPoints - user.AlfaPoints);
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
## Summary
- Users can designate **one bet per round** as a Joker that **doubles base points** if correct (1→2, 2→4, 4→8)
- Dixit bonus is **not doubled** — added separately after the Joker multiplier
- Joker can be changed until the match starts; once a joker match begins, the round's joker is **locked**
- Joker toggle is available immediately (before saving a bet) and persists automatically when the bet is saved
- Joker indicator (★ badge + doubled points) visible on the main page

## Changes
- **Models**: `Round` on Match, `IsJoker` on MatchBet + EF migrations
- **API**: `POST /api/bets/joker` endpoint with full validation
- **Scoring**: Joker multiplier in `GroupMatchesResultCoordinator`
- **Frontend**: Round-grouped betting UI, joker toggle, main page indicator, rules page section
- **Tests**: 28 new backend tests (scoring edge cases, controller validation, locked joker)

## Test plan
- [x] Verify joker toggle appears on all unlocked group matches
- [x] Verify selecting joker on one match clears it from another in the same round
- [x] Verify joker locks after match starts (cannot change round's joker)
- [x] Verify correct scoring: WINNER→2, DIFFERENCE→4, SCORE→8 with joker
- [x] Verify Dixit bonus is added separately (not doubled)
- [x] Verify joker indicator shows on main page
- [x] Verify `dotnet test` passes (169 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)