### PR TITLE
View all players' bets per match

### DIFF
--- a/ClientApp/src/components/MainPage/AlfaMatches.tsx
+++ b/ClientApp/src/components/MainPage/AlfaMatches.tsx
@@ -1,14 +1,18 @@
 import * as React from 'react';
 import { Match, Bet, TournamentStage } from "../../typings/index";
 import { MainRow } from './MainRow';
+import { MatchBetsModal } from './MatchBetsModal';
 import { Loader } from '../Loader';
 import { getApi } from '../api/ApiFactory';
+import authService from './../api-authorization/AuthorizeService';
 import './../../custom.css';
 
 interface AlfaMatchesState {
     matches: Match[];
     bets: Bet[];
     loading: boolean;
+    selectedMatch: Match | null;
+    currentUserId: string;
 }
 
 interface AlfaMatchesProps { }
@@ -21,7 +25,9 @@ export class AlfaMatches extends React.Component<AlfaMatchesProps, AlfaMatchesSt
         this.state = {
             matches: [],
             bets: [],
-            loading: true
+            loading: true,
+            selectedMatch: null,
+            currentUserId: "",
         };
     }
 
@@ -37,6 +43,13 @@ export class AlfaMatches extends React.Component<AlfaMatchesProps, AlfaMatchesSt
         return (
             <div className="alfa-matches">
                 {contents}
+                {this.state.selectedMatch && (
+                    <MatchBetsModal
+                        match={this.state.selectedMatch}
+                        currentUserId={this.state.currentUserId}
+                        onClose={() => this.setState({ selectedMatch: null })}
+                    />
+                )}
             </div>
         );
     }
@@ -45,14 +58,20 @@ export class AlfaMatches extends React.Component<AlfaMatchesProps, AlfaMatchesSt
         const matches = await getApi().getMatches(TournamentStage.Group);
         let userId = window.location.pathname.startsWith('/user/') ? window.location.pathname.substring(6) : undefined;
         const bets = !!userId ? await getApi().getBets(userId) : await getApi().getBets();
-        this.setState({ matches: matches, bets: bets, loading: false });
+        const user = await authService.getUser();
+        this.setState({ matches: matches, bets: bets, loading: false, currentUserId: user ? user["sub"] : "" });
     }
 
     private renderMatchTable() {
         return (
             <div className="main-match-card-list">
                 {this.state.matches.map((match) => (
-                    <MainRow key={match.id} match={match} bet={this.getBet(match)} />
+                    <MainRow
+                        key={match.id}
+                        match={match}
+                        bet={this.getBet(match)}
+                        onClick={this.isMatchClickable(match) ? () => this.setState({ selectedMatch: match }) : undefined}
+                    />
                 ))}
             </div>
         );
@@ -60,5 +79,9 @@ export class AlfaMatches extends React.Component<AlfaMatchesProps, AlfaMatchesSt
 
     private getBet(match: Match): Bet | undefined {
         return this.state.bets.find(b => b.match.id === match.id);
+    }
+
+    private isMatchClickable(match: Match): boolean {
+        return match.ended || new Date(match.startTime) <= new Date();
     }
 }

--- a/ClientApp/src/components/MainPage/MainPage.tsx
+++ b/ClientApp/src/components/MainPage/MainPage.tsx
@@ -28,9 +28,9 @@ export class MainPage extends React.Component<MainPageProps, MainPageState> {
 
     public render() {
         return (
-            <div className="container body-content">
+            <div className="container-fluid body-content" style={{ maxWidth: '1400px' }}>
                 <div className="row">
-                    <div className="col">
+                    <div className="col-lg-9">
                         <MainInnerPage activeStage={this.state.activeStage} user={undefined} />
                     </div>
                     <div className="col-lg-3">

--- a/ClientApp/src/components/MainPage/MainRow.tsx
+++ b/ClientApp/src/components/MainPage/MainRow.tsx
@@ -4,19 +4,21 @@ import { Match, Bet, BetResult } from "../../typings/index";
 interface MainRowProps {
     match: Match;
     bet: Bet | undefined;
+    onClick?: () => void;
 }
 
 export class MainRow extends React.Component<MainRowProps> {
     public render() {
-        const { match, bet } = this.props;
+        const { match, bet, onClick } = this.props;
         const isPlayed = match.ended;
         const hasBet = !!bet;
         const classes = ['main-match-card'];
         if (isPlayed && hasBet) classes.push(this.getCardBorderClass(bet!));
         if (hasBet && bet!.isJoker) classes.push('main-match-card-joker');
+        if (onClick) classes.push('main-match-card-clickable');
 
         return (
-            <div className={classes.join(' ')}>
+            <div className={classes.join(' ')} onClick={onClick} style={onClick ? { cursor: 'pointer' } : undefined}>
                 {/* Points badge - prominent, right side */}
                 {isPlayed && hasBet && this.renderPointsBadge(bet!)}
 

--- a/ClientApp/src/components/MainPage/MatchBetsModal.tsx
+++ b/ClientApp/src/components/MainPage/MatchBetsModal.tsx
@@ -1,0 +1,98 @@
+import * as React from 'react';
+import { Match, Bet, BetResult } from '../../typings/index';
+import { getApi } from '../api/ApiFactory';
+
+interface MatchBetsModalProps {
+    match: Match;
+    currentUserId: string;
+    onClose: () => void;
+}
+
+interface MatchBetsModalState {
+    bets: Bet[];
+    loading: boolean;
+    error: string | null;
+}
+
+export class MatchBetsModal extends React.Component<MatchBetsModalProps, MatchBetsModalState> {
+    constructor(props: MatchBetsModalProps) {
+        super(props);
+        this.state = { bets: [], loading: true, error: null };
+    }
+
+    public componentDidMount() {
+        this.loadBets();
+    }
+
+    private async loadBets() {
+        try {
+            const bets = await getApi().getBetsForMatch(this.props.match.id);
+            bets.sort((a, b) => this.getPoints(b) - this.getPoints(a));
+            this.setState({ bets, loading: false });
+        } catch {
+            this.setState({ error: 'Nepodařilo se načíst sázky.', loading: false });
+        }
+    }
+
+    private getPoints(bet: Bet): number {
+        const base = bet.isJoker && bet.result !== BetResult.nothing ? bet.result * 2 : bet.result;
+        return base + (bet.dixitBonus ?? 0);
+    }
+
+    private getPointsClass(result: BetResult): string {
+        switch (result) {
+            case BetResult.score: return 'modal-bet-points-score';
+            case BetResult.difference: return 'modal-bet-points-difference';
+            case BetResult.winner: return 'modal-bet-points-winner';
+            case BetResult.nothing: return 'modal-bet-points-nothing';
+            default: return '';
+        }
+    }
+
+    public render() {
+        const { match, onClose } = this.props;
+
+        return (
+            <div className="modal-bet-overlay" onClick={onClose}>
+                <div className="modal-bet-card" onClick={e => e.stopPropagation()}>
+                    <button className="modal-bet-close" onClick={onClose}>&times;</button>
+
+                    <div className="modal-bet-header">
+                        <div className="modal-bet-team">
+                            <img src={process.env.PUBLIC_URL + match.home.iconPath} width="28" height="28" alt={match.home.name} />
+                            <span>{match.home.name}</span>
+                        </div>
+                        <div className="modal-bet-score">
+                            {match.result.homeTeam} : {match.result.awayTeam}
+                        </div>
+                        <div className="modal-bet-team">
+                            <img src={process.env.PUBLIC_URL + match.away.iconPath} width="28" height="28" alt={match.away.name} />
+                            <span>{match.away.name}</span>
+                        </div>
+                    </div>
+
+                    <div className="modal-bet-list">
+                        {this.state.loading && <div className="modal-bet-loading">Načítání...</div>}
+                        {this.state.error && <div className="modal-bet-loading">{this.state.error}</div>}
+                        {!this.state.loading && !this.state.error && this.state.bets.length === 0 && (
+                            <div className="modal-bet-loading">Žádné sázky.</div>
+                        )}
+                        {this.state.bets.map(bet => {
+                            const isCurrentUser = bet.user?.id === this.props.currentUserId;
+                            const points = this.getPoints(bet);
+                            return (
+                                <div key={bet.id} className={`modal-bet-row ${isCurrentUser ? 'modal-bet-row-current' : ''}`}>
+                                    <span className="modal-bet-player">{bet.user?.userName ?? '?'}</span>
+                                    <span className="modal-bet-tip">{bet.tip.homeTeam}:{bet.tip.awayTeam}</span>
+                                    <span className={`modal-bet-points ${this.getPointsClass(bet.result)}`}>
+                                        {points}b
+                                    </span>
+                                </div>
+                            );
+                        })}
+                    </div>
+                </div>
+            </div>
+        );
+    }
+}

--- a/ClientApp/src/components/MainPage/MatchStages.tsx
+++ b/ClientApp/src/components/MainPage/MatchStages.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
 import { Match, Bet, UpdateStatus, TournamentStage } from "../../typings/index"
 import { MainRow } from './MainRow';
+import { MatchBetsModal } from './MatchBetsModal';
 import { getApi } from "../api/ApiFactory"
 import { Loader } from '../Loader'
+import authService from './../api-authorization/AuthorizeService';
 
 
 interface MatchStagesProps {
@@ -14,6 +16,8 @@ interface MatchStagesState {
     matches: Match[],
     bets: Bet[];
     loading: boolean;
+    selectedMatch: Match | null;
+    currentUserId: string;
 }
 
 export class MatchStages extends React.Component<MatchStagesProps, MatchStagesState> {
@@ -24,6 +28,8 @@ export class MatchStages extends React.Component<MatchStagesProps, MatchStagesSt
             matches: [],
             bets: [],
             loading: true,
+            selectedMatch: null,
+            currentUserId: "",
         }
     }
 
@@ -41,6 +47,13 @@ export class MatchStages extends React.Component<MatchStagesProps, MatchStagesSt
         return (
             <div className="col">
                 {contents}
+                {this.state.selectedMatch && (
+                    <MatchBetsModal
+                        match={this.state.selectedMatch}
+                        currentUserId={this.state.currentUserId}
+                        onClose={() => this.setState({ selectedMatch: null })}
+                    />
+                )}
             </div>
         );
     }
@@ -48,14 +61,20 @@ export class MatchStages extends React.Component<MatchStagesProps, MatchStagesSt
     private async getData() {
         const matches = await getApi().getMatches(this.props.stage);
         const bets = await getApi().getBets(undefined);
-        this.setState({ matches: matches, bets: bets, loading: false });
+        const user = await authService.getUser();
+        this.setState({ matches: matches, bets: bets, loading: false, currentUserId: user ? user["sub"] : "" });
     }
 
     private renderMatchTable() {
         return (
             <div className="main-match-card-list">
                 {this.state.matches.map((match) => (
-                    <MainRow key={match.id} match={match} bet={this.getBet(match)} />
+                    <MainRow
+                        key={match.id}
+                        match={match}
+                        bet={this.getBet(match)}
+                        onClick={this.isMatchClickable(match) ? () => this.setState({ selectedMatch: match }) : undefined}
+                    />
                 ))}
             </div>
         );
@@ -71,5 +90,9 @@ export class MatchStages extends React.Component<MatchStagesProps, MatchStagesSt
 
     private getBet(match: Match): Bet | undefined {
        return this.state.bets.find(b => b.match.id == match.id);
+    }
+
+    private isMatchClickable(match: Match): boolean {
+        return match.ended || new Date(match.startTime) <= new Date();
     }
 }

--- a/ClientApp/src/components/MainPage/Ranking.tsx
+++ b/ClientApp/src/components/MainPage/Ranking.tsx
@@ -44,7 +44,7 @@ export class Ranking extends React.Component<RankingProps, RankingState> {
             : this.renderRanking();
 
         return (
-            <div className="col-12 col-md-8 offset-md-2" style={{ paddingLeft: "0px" }} >
+            <div>
                 <h1 id="tabelLabel" className="header">Pořadí</h1>
                 {contents}
             </div>

--- a/ClientApp/src/components/NavMenu.tsx
+++ b/ClientApp/src/components/NavMenu.tsx
@@ -56,9 +56,6 @@ export class NavMenu extends React.Component<INavMenuProps, INavMenuState> {
                   <NavLink tag={Link} to="/tips">Sázky</NavLink>
                 </NavItem>
                 <NavItem>
-                  <NavLink tag={Link} to="/bets/all">Všechny sázky</NavLink>
-                </NavItem>
-                <NavItem>
                     <NavLink tag={Link} to="/rules">Pravidla</NavLink>
                 </NavItem>
                 <LoginMenu>
@@ -76,7 +73,6 @@ export class NavMenu extends React.Component<INavMenuProps, INavMenuState> {
           <Link to="/" className="drawer-brand" onClick={this.closeDrawer}>Tipovačka EURO 2024</Link>
           <ul className="drawer-nav">
             <li><Link to="/tips" onClick={this.closeDrawer}>Sázky</Link></li>
-            <li><Link to="/bets/all" onClick={this.closeDrawer}>Všechny sázky</Link></li>
             <li><Link to="/rules" onClick={this.closeDrawer}>Pravidla</Link></li>
           </ul>
           <hr className="drawer-divider" />

--- a/ClientApp/src/components/api/Api.ts
+++ b/ClientApp/src/components/api/Api.ts
@@ -88,6 +88,10 @@ export class Api implements IApi {
         await post(`${API_URL}/bets/joker?matchId=${matchId}`);
     }
 
+    getBetsForMatch(matchId: string): Promise<Bet[]> {
+        return convert<Bet[]>(get(`${API_URL}/bets/match/${matchId}`));
+    }
+
     async uploadTip(tip: Result, matchId: string): Promise<void> {
         await post(`${API_URL}/bets/tip/`, { tip: tip, matchId: matchId });
     }

--- a/ClientApp/src/components/api/IApi.d.ts
+++ b/ClientApp/src/components/api/IApi.d.ts
@@ -26,4 +26,5 @@ export interface IApi {
     getGroups(): Promise<Group[]>
     uploadGroupBet(bet: GroupBet, groupId: string): Promise<void>;
     setJoker(matchId: string): Promise<void>;
+    getBetsForMatch(matchId: string): Promise<Bet[]>;
 }

--- a/ClientApp/src/custom.css
+++ b/ClientApp/src/custom.css
@@ -231,6 +231,7 @@ code {
 
 .card-body {
     padding: 1.25rem;
+    overflow: hidden;
 }
 
 /* ===== Deadline Badge ===== */
@@ -1349,15 +1350,15 @@ code {
     display: flex;
     align-items: stretch;
     min-height: 500px;
-    min-width: 800px;
+    min-width: 650px;
 }
 
 .bracket-round {
     display: flex;
     flex-direction: column;
     flex: 1;
-    min-width: 150px;
-    max-width: 200px;
+    min-width: 130px;
+    max-width: 180px;
 }
 
 .bracket-round-title {
@@ -1510,6 +1511,159 @@ code {
 .special-bet-result-fail {
     background: var(--danger-bg);
     color: var(--danger);
+}
+
+/* ===== Match Bets Modal ===== */
+.modal-bet-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 1060;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--space-md);
+}
+
+.modal-bet-card {
+    background: var(--surface);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-lg);
+    width: 100%;
+    max-width: 420px;
+    max-height: 80vh;
+    display: flex;
+    flex-direction: column;
+    position: relative;
+    overflow: hidden;
+}
+
+.modal-bet-close {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.75rem;
+    background: none;
+    border: none;
+    font-size: 1.5rem;
+    color: var(--text-muted);
+    cursor: pointer;
+    line-height: 1;
+    z-index: 1;
+}
+
+.modal-bet-close:hover {
+    color: var(--text);
+}
+
+.modal-bet-header {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-md);
+    padding: var(--space-lg) var(--space-lg) var(--space-md);
+    border-bottom: 1px solid var(--border-light);
+}
+
+.modal-bet-team {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    font-weight: 600;
+    font-size: var(--font-sm);
+}
+
+.modal-bet-score {
+    font-weight: 800;
+    font-size: var(--font-lg);
+    color: var(--text);
+}
+
+.modal-bet-list {
+    overflow-y: auto;
+    padding: var(--space-sm) 0;
+}
+
+.modal-bet-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    padding: 0.5rem var(--space-lg);
+    transition: background var(--transition-fast);
+}
+
+.modal-bet-row:hover {
+    background: var(--bg);
+}
+
+.modal-bet-row-current {
+    background: #2b6cb0 !important;
+}
+
+.modal-bet-row-current .modal-bet-player,
+.modal-bet-row-current .modal-bet-tip {
+    color: #fff !important;
+    font-weight: 700;
+}
+
+.modal-bet-row-current:hover {
+    background: #2c5282 !important;
+}
+
+.modal-bet-player {
+    flex: 1;
+    font-weight: 500;
+    font-size: var(--font-sm);
+    color: var(--text);
+}
+
+.modal-bet-tip {
+    font-size: var(--font-sm);
+    color: var(--text-secondary);
+    font-weight: 600;
+    min-width: 36px;
+    text-align: center;
+}
+
+.modal-bet-points {
+    font-size: var(--font-xs);
+    font-weight: 700;
+    padding: 0.15rem 0.5rem;
+    border-radius: var(--radius-pill);
+    min-width: 32px;
+    text-align: center;
+}
+
+.modal-bet-points-score {
+    background: #c6f6d5;
+    color: #276749;
+}
+
+.modal-bet-points-difference {
+    background: #fefcbf;
+    color: #975a16;
+}
+
+.modal-bet-points-winner {
+    background: #bee3f8;
+    color: #2b6cb0;
+}
+
+.modal-bet-points-nothing {
+    background: #fed7d7;
+    color: #c53030;
+}
+
+.modal-bet-loading {
+    text-align: center;
+    padding: var(--space-lg);
+    color: var(--text-muted);
+    font-size: var(--font-sm);
+}
+
+/* Clickable match card indicator */
+.main-match-card-clickable:hover {
+    box-shadow: var(--shadow-hover);
+    border-color: var(--primary-light);
 }
 
 /* ===== Mobile Optimizations (Phase 7) ===== */

--- a/Controllers/BetsController.cs
+++ b/Controllers/BetsController.cs
@@ -262,6 +262,24 @@ namespace TipTournament2._0.Controllers
             return new OkResult();
         }
 
+        [HttpGet("match/{matchId}")]
+        public IActionResult GetBetsForMatch([FromRoute] string matchId)
+        {
+            var match = this.context.GetMatchById(matchId);
+            if (match == null)
+            {
+                return NotFound("Zápas nebyl nalezen.");
+            }
+
+            if (DateTime.UtcNow < match.StartTime)
+            {
+                return BadRequest("Sázky na tento zápas ještě nelze zobrazit.");
+            }
+
+            var bets = this.context.GetBetsForMatch(match);
+            return new OkObjectResult(bets);
+        }
+
         [HttpPost("users")]
         public IActionResult GetBets([FromBody] string[] userIds)
         {

--- a/Data/DbContextWrapper.cs
+++ b/Data/DbContextWrapper.cs
@@ -136,6 +136,7 @@
             return this.dbContext.Bets
                 .Include(b => b.Match)
                 .Include(b => b.Tip)
+                .Include(b => b.User)
                 .Where(b => b.Match.Id == match.Id)
                 .ToList();
         }


### PR DESCRIPTION
## Summary
- **Match bets modal**: Click any played/started match card on the main page to see all players' bets for that match, sorted by points (best first), with current user highlighted in blue
- **New API endpoint**: `GET /api/bets/match/{matchId}` returns all bets for a match only after kickoff (prevents peeking)
- **Layout fix**: Accordion expanding (Delta bracket) no longer pushes ranking column below — uses wider container and explicit column sizing
- **Nav cleanup**: Removed "Všechny sázky" link from desktop nav and mobile drawer

## Test plan
- [x] Click a played match on the main page — modal opens showing all players' bets
- [ ] Unplayed matches are not clickable
- [x] Current user's row is highlighted in blue in the modal
- [x] Open Delta bracket accordion — ranking stays on the side, no horizontal scrollbar
- [x] "Všechny sázky" no longer appears in nav bar or mobile drawer

🤖 Generated with [Claude Code](https://claude.com/claude-code)