### PR TITLE
Add statistics page

### DIFF
--- a/ClientApp/package-lock.json
+++ b/ClientApp/package-lock.json
@@ -30,6 +30,7 @@
         "react-spinner": "^0.2.7",
         "react-tooltip": "^4.5.0",
         "reactstrap": "^8.9.0",
+        "recharts": "^2.1.16",
         "rimraf": "^2.6.2"
       },
       "devDependencies": {
@@ -4109,6 +4110,51 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/d3-color": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-2.0.6.tgz",
+      "integrity": "sha512-tbaFGDmJWHqnenvk3QGSvD3RVwr631BjKRD7Sc7VLRgrdX5mk5hTyoeBL6rXZaeoXzmZwIl1D2HPogEdt1rHBg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-2.0.5.tgz",
+      "integrity": "sha512-UINE41RDaUMbulp+bxQMDnhOi51rh5lA2dG+dWZU0UY/IwQiG/u2x8TfnWYU9+xwGdXsJoAvrBYUEQl0r91atg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "^2"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-2.0.4.tgz",
+      "integrity": "sha512-jjZVLBjEX4q6xneKMmv62UocaFJFOTQSb/1aTzs3m3ICTOFoVaqGBHpNLm/4dVi0/FTltfBKgmOK1ECj3/gGjA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-3.3.5.tgz",
+      "integrity": "sha512-YOpKj0kIEusRf7ofeJcSZQsvKbnTwpe1DUF+P2qsotqG53kEsjm7EzzliqQxMkAWdkZcHrg5rRhB4JiDOQPX+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "^2"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-2.1.7.tgz",
+      "integrity": "sha512-HedHlfGHdwzKqX9+PiQVXZrdmGlwo7naoefJP7kCNk4Y7qcpQt1tUaoRa6qn0kbTdlaIHGO7111qLtb/6J8uuw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "^2"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-2.1.4.tgz",
+      "integrity": "sha512-BTfLsxTeo7yFxI/haOOf1ZwJ6xKgQLT9dCp+EcmQv87Gox6X+oKl4mLKfO6fnWm3P22+A6DknMNEZany8ql2Rw==",
+      "license": "MIT"
+    },
     "node_modules/@types/eslint": {
       "version": "8.4.10",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.10.tgz",
@@ -6680,6 +6726,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/css-unit-converter": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.2.tgz",
+      "integrity": "sha512-IiJwMC8rdZE0+xiEZHeru6YoONC4rfPMqGm2W85jMIbkFvv5nFTwJVFHam2eFrN6txmoUYFAFXiv8ICVeTO0MA==",
+      "license": "MIT"
+    },
     "node_modules/css-what": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
@@ -6842,9 +6894,86 @@
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg=="
     },
     "node_modules/csstype": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
+      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-format": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
+      "integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-interpolate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
+      "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-color": "1 - 2"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-2.0.0.tgz",
+      "integrity": "sha512-ZwZQxKhBnv9yHaiWd6ZU4x5BtCQ7pXszEV9CU6kRgwIQVQGLMv1oiL4M+MK/n79sYzsj+gcgpPQSctJUsLN7fA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-scale": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
+      "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "^2.3.0",
+        "d3-format": "1 - 2",
+        "d3-interpolate": "1.2.0 - 2",
+        "d3-time": "^2.1.1",
+        "d3-time-format": "2 - 3"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-2.1.0.tgz",
+      "integrity": "sha512-PnjUqfM2PpskbSLTJvAzp2Wv4CZsnAgTfcVRTwW03QR3MkXF8Uo7B1y/lWkAsmbKwuecto++4NlsYcvYpXpTHA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1 - 2"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
+      "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "2"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
+      "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-time": "1 - 2"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -6884,6 +7013,12 @@
       "version": "10.4.2",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.2.tgz",
       "integrity": "sha512-ic1yEvwT6GuvaYwBLLY6/aFFgjZdySKTE8en/fkU3QICTmRtgtSlFn0u0BXN06InZwtfCelR7j8LRiDI/02iGA=="
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/dedent": {
       "version": "0.7.0",
@@ -8177,6 +8312,15 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "node_modules/fast-equals": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
+      "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-glob": {
       "version": "3.2.12",
@@ -9503,6 +9647,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
     },
     "node_modules/invariant": {
       "version": "2.2.4",
@@ -16281,6 +16431,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-resize-detector": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-7.1.2.tgz",
+      "integrity": "sha512-zXnPJ2m8+6oq9Nn8zsep/orts9vQv3elrpA+R8XTcW7DVVUJ9vwDwMXaBtykAYjMnkCIaOoK9vObyR7ZgFNlOw==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-router": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
@@ -17147,6 +17310,37 @@
         "node": ">= 8"
       }
     },
+    "node_modules/react-smooth": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-2.0.5.tgz",
+      "integrity": "sha512-BMP2Ad42tD60h0JW6BFaib+RJuV5dsXJK9Baxiv/HlNFjvRLqA9xrNKxVWnUIZPQfzUwGXIlU/dSYLU+54YGQA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.0",
+        "react-transition-group": "2.9.0"
+      },
+      "peerDependencies": {
+        "prop-types": "^15.6.0",
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/react-smooth/node_modules/react-transition-group": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
+      "integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "dom-helpers": "^3.4.0",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2",
+        "react-lifecycles-compat": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react": ">=15.0.0",
+        "react-dom": ">=15.0.0"
+      }
+    },
     "node_modules/react-spinner": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/react-spinner/-/react-spinner-0.2.7.tgz",
@@ -17242,6 +17436,45 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/recharts": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.1.16.tgz",
+      "integrity": "sha512-aYn1plTjYzRCo3UGxtWsduslwYd+Cuww3h/YAAEoRdGe0LRnBgYgaXSlVrNFkWOOSXrBavpmnli9h7pvRuk5wg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "^2.0.0",
+        "@types/d3-scale": "^3.0.0",
+        "@types/d3-shape": "^2.0.0",
+        "classnames": "^2.2.5",
+        "d3-interpolate": "^2.0.0",
+        "d3-scale": "^3.0.0",
+        "d3-shape": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.19",
+        "react-is": "^16.10.2",
+        "react-resize-detector": "^7.1.2",
+        "react-smooth": "^2.0.1",
+        "recharts-scale": "^0.4.4",
+        "reduce-css-calc": "^2.1.8"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "prop-types": "^15.6.0",
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
     "node_modules/recursive-readdir": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.3.tgz",
@@ -17252,6 +17485,22 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/reduce-css-calc": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-2.1.8.tgz",
+      "integrity": "sha512-8liAVezDmUcH+tdzoEGrhfbGcP7nOV4NkGE3a74+qqvE7nt9i4sKLGBuZNOnpI4WiGksiNPklZxva80061QiPg==",
+      "license": "MIT",
+      "dependencies": {
+        "css-unit-converter": "^1.1.1",
+        "postcss-value-parser": "^3.3.0"
+      }
+    },
+    "node_modules/reduce-css-calc/node_modules/postcss-value-parser": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+      "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+      "license": "MIT"
     },
     "node_modules/regenerate": {
       "version": "1.4.2",
@@ -18822,9 +19071,10 @@
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
     },
     "node_modules/tiny-invariant": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
-      "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw=="
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
     },
     "node_modules/tiny-warning": {
       "version": "1.0.3",
@@ -23050,6 +23300,45 @@
         "@types/node": "*"
       }
     },
+    "@types/d3-color": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-2.0.6.tgz",
+      "integrity": "sha512-tbaFGDmJWHqnenvk3QGSvD3RVwr631BjKRD7Sc7VLRgrdX5mk5hTyoeBL6rXZaeoXzmZwIl1D2HPogEdt1rHBg=="
+    },
+    "@types/d3-interpolate": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-2.0.5.tgz",
+      "integrity": "sha512-UINE41RDaUMbulp+bxQMDnhOi51rh5lA2dG+dWZU0UY/IwQiG/u2x8TfnWYU9+xwGdXsJoAvrBYUEQl0r91atg==",
+      "requires": {
+        "@types/d3-color": "^2"
+      }
+    },
+    "@types/d3-path": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-2.0.4.tgz",
+      "integrity": "sha512-jjZVLBjEX4q6xneKMmv62UocaFJFOTQSb/1aTzs3m3ICTOFoVaqGBHpNLm/4dVi0/FTltfBKgmOK1ECj3/gGjA=="
+    },
+    "@types/d3-scale": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-3.3.5.tgz",
+      "integrity": "sha512-YOpKj0kIEusRf7ofeJcSZQsvKbnTwpe1DUF+P2qsotqG53kEsjm7EzzliqQxMkAWdkZcHrg5rRhB4JiDOQPX+A==",
+      "requires": {
+        "@types/d3-time": "^2"
+      }
+    },
+    "@types/d3-shape": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-2.1.7.tgz",
+      "integrity": "sha512-HedHlfGHdwzKqX9+PiQVXZrdmGlwo7naoefJP7kCNk4Y7qcpQt1tUaoRa6qn0kbTdlaIHGO7111qLtb/6J8uuw==",
+      "requires": {
+        "@types/d3-path": "^2"
+      }
+    },
+    "@types/d3-time": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-2.1.4.tgz",
+      "integrity": "sha512-BTfLsxTeo7yFxI/haOOf1ZwJ6xKgQLT9dCp+EcmQv87Gox6X+oKl4mLKfO6fnWm3P22+A6DknMNEZany8ql2Rw=="
+    },
     "@types/eslint": {
       "version": "8.4.10",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.10.tgz",
@@ -24976,6 +25265,11 @@
         }
       }
     },
+    "css-unit-converter": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.2.tgz",
+      "integrity": "sha512-IiJwMC8rdZE0+xiEZHeru6YoONC4rfPMqGm2W85jMIbkFvv5nFTwJVFHam2eFrN6txmoUYFAFXiv8ICVeTO0MA=="
+    },
     "css-what": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
@@ -25093,9 +25387,76 @@
       }
     },
     "csstype": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
-      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
+    },
+    "d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "requires": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "d3-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz",
+      "integrity": "sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ=="
+    },
+    "d3-format": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-2.0.0.tgz",
+      "integrity": "sha512-Ab3S6XuE/Q+flY96HXT0jOXcM4EAClYFnRGY5zsjRGNy6qCYrQsMffs7cV5Q9xejb35zxW5hf/guKw34kvIKsA=="
+    },
+    "d3-interpolate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-2.0.1.tgz",
+      "integrity": "sha512-c5UhwwTs/yybcmTpAVqwSFl6vrQ8JZJoT5F7xNFK9pymv5C0Ymcc9/LIJHtYIggg/yS9YHw8i8O8tgb9pupjeQ==",
+      "requires": {
+        "d3-color": "1 - 2"
+      }
+    },
+    "d3-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-2.0.0.tgz",
+      "integrity": "sha512-ZwZQxKhBnv9yHaiWd6ZU4x5BtCQ7pXszEV9CU6kRgwIQVQGLMv1oiL4M+MK/n79sYzsj+gcgpPQSctJUsLN7fA=="
+    },
+    "d3-scale": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-3.3.0.tgz",
+      "integrity": "sha512-1JGp44NQCt5d1g+Yy+GeOnZP7xHo0ii8zsQp6PGzd+C1/dl0KGsp9A7Mxwp+1D1o4unbTTxVdU/ZOIEBoeZPbQ==",
+      "requires": {
+        "d3-array": "^2.3.0",
+        "d3-format": "1 - 2",
+        "d3-interpolate": "1.2.0 - 2",
+        "d3-time": "^2.1.1",
+        "d3-time-format": "2 - 3"
+      }
+    },
+    "d3-shape": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-2.1.0.tgz",
+      "integrity": "sha512-PnjUqfM2PpskbSLTJvAzp2Wv4CZsnAgTfcVRTwW03QR3MkXF8Uo7B1y/lWkAsmbKwuecto++4NlsYcvYpXpTHA==",
+      "requires": {
+        "d3-path": "1 - 2"
+      }
+    },
+    "d3-time": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-2.1.1.tgz",
+      "integrity": "sha512-/eIQe/eR4kCQwq7yxi7z4c6qEXf2IYGcjoWB5OOQy4Tq9Uv39/947qlDcN2TLkiTzQWzvnsuYPB9TrWaNfipKQ==",
+      "requires": {
+        "d3-array": "2"
+      }
+    },
+    "d3-time-format": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-3.0.0.tgz",
+      "integrity": "sha512-UXJh6EKsHBTjopVqZBhFysQcoXSv/5yLONZvkQ5Kk3qbwiUYkdX17Xa1PT6U1ZWXGGfB1ey5L8dKMlFq2DO0Ag==",
+      "requires": {
+        "d3-time": "1 - 2"
+      }
     },
     "damerau-levenshtein": {
       "version": "1.0.8",
@@ -25124,6 +25485,11 @@
       "version": "10.4.2",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.2.tgz",
       "integrity": "sha512-ic1yEvwT6GuvaYwBLLY6/aFFgjZdySKTE8en/fkU3QICTmRtgtSlFn0u0BXN06InZwtfCelR7j8LRiDI/02iGA=="
+    },
+    "decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
     },
     "dedent": {
       "version": "0.7.0",
@@ -26100,6 +26466,11 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
+    "fast-equals": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.4.0.tgz",
+      "integrity": "sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw=="
+    },
     "fast-glob": {
       "version": "3.2.12",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
@@ -27058,6 +27429,11 @@
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
       }
+    },
+    "internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw=="
     },
     "invariant": {
       "version": "2.2.4",
@@ -31846,6 +32222,14 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A=="
     },
+    "react-resize-detector": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-7.1.2.tgz",
+      "integrity": "sha512-zXnPJ2m8+6oq9Nn8zsep/orts9vQv3elrpA+R8XTcW7DVVUJ9vwDwMXaBtykAYjMnkCIaOoK9vObyR7ZgFNlOw==",
+      "requires": {
+        "lodash": "^4.17.21"
+      }
+    },
     "react-router": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
@@ -32422,6 +32806,28 @@
         }
       }
     },
+    "react-smooth": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-2.0.5.tgz",
+      "integrity": "sha512-BMP2Ad42tD60h0JW6BFaib+RJuV5dsXJK9Baxiv/HlNFjvRLqA9xrNKxVWnUIZPQfzUwGXIlU/dSYLU+54YGQA==",
+      "requires": {
+        "fast-equals": "^5.0.0",
+        "react-transition-group": "2.9.0"
+      },
+      "dependencies": {
+        "react-transition-group": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
+          "integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
+          "requires": {
+            "dom-helpers": "^3.4.0",
+            "loose-envify": "^1.4.0",
+            "prop-types": "^15.6.2",
+            "react-lifecycles-compat": "^3.0.4"
+          }
+        }
+      }
+    },
     "react-spinner": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/react-spinner/-/react-spinner-0.2.7.tgz",
@@ -32493,12 +32899,57 @@
         "picomatch": "^2.2.1"
       }
     },
+    "recharts": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.1.16.tgz",
+      "integrity": "sha512-aYn1plTjYzRCo3UGxtWsduslwYd+Cuww3h/YAAEoRdGe0LRnBgYgaXSlVrNFkWOOSXrBavpmnli9h7pvRuk5wg==",
+      "requires": {
+        "@types/d3-interpolate": "^2.0.0",
+        "@types/d3-scale": "^3.0.0",
+        "@types/d3-shape": "^2.0.0",
+        "classnames": "^2.2.5",
+        "d3-interpolate": "^2.0.0",
+        "d3-scale": "^3.0.0",
+        "d3-shape": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.19",
+        "react-is": "^16.10.2",
+        "react-resize-detector": "^7.1.2",
+        "react-smooth": "^2.0.1",
+        "recharts-scale": "^0.4.4",
+        "reduce-css-calc": "^2.1.8"
+      }
+    },
+    "recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "requires": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
     "recursive-readdir": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.3.tgz",
       "integrity": "sha512-8HrF5ZsXk5FAH9dgsx3BlUer73nIhuj+9OrQwEbLTPOBzGkL1lsFCR01am+v+0m2Cmbs1nP12hLDl5FA7EszKA==",
       "requires": {
         "minimatch": "^3.0.5"
+      }
+    },
+    "reduce-css-calc": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-2.1.8.tgz",
+      "integrity": "sha512-8liAVezDmUcH+tdzoEGrhfbGcP7nOV4NkGE3a74+qqvE7nt9i4sKLGBuZNOnpI4WiGksiNPklZxva80061QiPg==",
+      "requires": {
+        "css-unit-converter": "^1.1.1",
+        "postcss-value-parser": "^3.3.0"
+      },
+      "dependencies": {
+        "postcss-value-parser": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
+          "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ=="
+        }
       }
     },
     "regenerate": {
@@ -33674,9 +34125,9 @@
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA=="
     },
     "tiny-invariant": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.1.tgz",
-      "integrity": "sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw=="
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
     },
     "tiny-warning": {
       "version": "1.0.3",

--- a/ClientApp/package.json
+++ b/ClientApp/package.json
@@ -25,6 +25,7 @@
     "react-spinner": "^0.2.7",
     "react-tooltip": "^4.5.0",
     "reactstrap": "^8.9.0",
+    "recharts": "^2.1.16",
     "rimraf": "^2.6.2"
   },
   "devDependencies": {

--- a/ClientApp/src/App.js
+++ b/ClientApp/src/App.js
@@ -7,6 +7,7 @@ import { AllBets } from './components/Bets/AllBets'
 import { UserBetPage } from './components/Bets/UserBetPage'
 import { AdminPage } from './components/Admin/AdminPage'
 import { RulePage } from './components/RulePage'
+import { StatsPage } from './components/Stats/StatsPage'
 import AuthorizeRoute from './components/api-authorization/AuthorizeRoute';
 //import AdminAuthorizeRoute from './components/api-authorization/AdminAuthorizeRoute';
 import ApiAuthorizationRoutes from './components/api-authorization/ApiAuthorizationRoutes';
@@ -28,6 +29,7 @@ export default class App extends Component {
         <AuthorizeRoute exact path="/user/:userId" component={UserBetPage} />
         <Route path={ApplicationPaths.ApiAuthorizationPrefix} component={ApiAuthorizationRoutes} />
         <Route exact path="/rules" component={RulePage} />
+        <AuthorizeRoute exact path="/stats" component={StatsPage} />
       </Layout>
     );
   }

--- a/ClientApp/src/components/NavMenu.tsx
+++ b/ClientApp/src/components/NavMenu.tsx
@@ -58,6 +58,9 @@ export class NavMenu extends React.Component<INavMenuProps, INavMenuState> {
                 <NavItem>
                     <NavLink tag={Link} to="/rules">Pravidla</NavLink>
                 </NavItem>
+                <NavItem>
+                    <NavLink tag={Link} to="/stats">Statistiky</NavLink>
+                </NavItem>
                 <LoginMenu>
                 </LoginMenu>
               </ul>
@@ -74,6 +77,7 @@ export class NavMenu extends React.Component<INavMenuProps, INavMenuState> {
           <ul className="drawer-nav">
             <li><Link to="/tips" onClick={this.closeDrawer}>Sázky</Link></li>
             <li><Link to="/rules" onClick={this.closeDrawer}>Pravidla</Link></li>
+            <li><Link to="/stats" onClick={this.closeDrawer}>Statistiky</Link></li>
           </ul>
           <hr className="drawer-divider" />
           <ul className="drawer-nav">

--- a/ClientApp/src/components/Stats/RankingChart.tsx
+++ b/ClientApp/src/components/Stats/RankingChart.tsx
@@ -1,0 +1,215 @@
+import * as React from 'react';
+import { RankingOverTimeEntry } from '../../typings';
+import {
+    LineChart,
+    Line,
+    XAxis,
+    YAxis,
+    CartesianGrid,
+    Tooltip,
+    ResponsiveContainer
+} from 'recharts';
+
+interface RankingChartProps {
+    data: RankingOverTimeEntry[];
+}
+
+const COLORS = [
+    '#2b6cb0', '#e53e3e', '#38a169', '#d69e2e', '#805ad5',
+    '#dd6b20', '#319795', '#d53f8c', '#3182ce', '#c53030',
+    '#2f855a', '#b7791f', '#6b46c1', '#c05621', '#2c7a7b',
+    '#b83280', '#4299e1', '#e53e3e', '#48bb78', '#ecc94b'
+];
+
+interface RankingChartState {
+    hiddenPlayers: Set<string>;
+}
+
+export class RankingChart extends React.Component<RankingChartProps, RankingChartState> {
+    constructor(props: RankingChartProps) {
+        super(props);
+        this.state = { hiddenPlayers: new Set() };
+    }
+
+    private getColorMap(): Map<string, string> {
+        const playerNames = this.props.data[0].playerPoints.map(p => p.userName);
+        const map = new Map<string, string>();
+        playerNames.forEach((name, i) => map.set(name, COLORS[i % COLORS.length]));
+        return map;
+    }
+
+    private handleInvert = () => {
+        const playerNames = this.props.data[0].playerPoints.map(p => p.userName);
+        const next = new Set<string>();
+        playerNames.forEach(name => {
+            if (!this.state.hiddenPlayers.has(name)) {
+                next.add(name);
+            }
+        });
+        this.setState({ hiddenPlayers: next });
+    }
+
+    render() {
+        const { data } = this.props;
+        if (!data || data.length === 0) {
+            return <p style={{ color: 'var(--text-muted)', textAlign: 'center' }}>Zatím žádná data</p>;
+        }
+
+        const playerNames = data[0].playerPoints.map(p => p.userName);
+        const totalPlayers = playerNames.length;
+        const colorMap = this.getColorMap();
+
+        // Convert cumulative points to ranks at each match
+        // Track phase label positions for X-axis dedup
+        const phaseMidpoints: { [label: string]: { sum: number; count: number } } = {};
+        const chartData = data.map((entry, idx) => {
+            const sorted = [...entry.playerPoints].sort((a, b) => b.cumulativePoints - a.cumulativePoints);
+            const rankMap: { [name: string]: number } = {};
+            sorted.forEach((p, i) => {
+                rankMap[p.userName] = i + 1;
+            });
+
+            const label = entry.matchLabel;
+            if (!phaseMidpoints[label]) {
+                phaseMidpoints[label] = { sum: 0, count: 0 };
+            }
+            phaseMidpoints[label].sum += idx;
+            phaseMidpoints[label].count += 1;
+
+            const point: any = {
+                name: label,
+                _index: idx
+            };
+            playerNames.forEach(name => {
+                point[name] = rankMap[name];
+            });
+            return point;
+        });
+
+        // Calculate midpoint index for each phase label
+        const labelAtIndex: { [idx: number]: string } = {};
+        Object.keys(phaseMidpoints).forEach(label => {
+            const mid = Math.round(phaseMidpoints[label].sum / phaseMidpoints[label].count);
+            labelAtIndex[mid] = label;
+        });
+
+        return (
+            <div>
+                <div style={{ textAlign: 'right', marginBottom: 'var(--space-sm)' }}>
+                    <button
+                        className="btn btn-secondary"
+                        style={{ fontSize: 'var(--font-xs)', padding: '0.25rem 0.75rem' }}
+                        onClick={this.handleInvert}
+                    >
+                        Invertovat výběr
+                    </button>
+                </div>
+                <ResponsiveContainer width="100%" height={400}>
+                    <LineChart data={chartData} margin={{ top: 5, right: 20, left: 0, bottom: 5 }}>
+                        <CartesianGrid strokeDasharray="3 3" stroke="var(--border-light)" />
+                        <XAxis
+                            dataKey="_index"
+                            tick={(tickProps: any) => {
+                                const label = labelAtIndex[tickProps.payload.value];
+                                if (!label) return <g />;
+                                return (
+                                    <text
+                                        x={tickProps.x} y={tickProps.y + 12}
+                                        textAnchor="middle"
+                                        fontSize={11} fill="var(--text-secondary)"
+                                    >
+                                        {label}
+                                    </text>
+                                );
+                            }}
+                            interval={0}
+                            type="number"
+                            domain={[0, chartData.length - 1]}
+                            tickCount={chartData.length}
+                        />
+                        <YAxis
+                            reversed
+                            domain={[1, totalPlayers]}
+                            tickCount={totalPlayers}
+                            tick={{ fontSize: 11, fill: 'var(--text-secondary)' }}
+                            label={{ value: 'Pořadí', angle: -90, position: 'insideLeft', style: { fontSize: 12, fill: 'var(--text-secondary)' } }}
+                        />
+                        <Tooltip
+                            content={({ active, payload }: any) => {
+                                if (!active || !payload || payload.length === 0) return null;
+                                const phaseName = payload[0]?.payload?.name || '';
+                                const items = payload
+                                    .filter((p: any) => p.value != null)
+                                    .sort((a: any, b: any) => a.value - b.value);
+                                return (
+                                    <div style={{
+                                        background: 'var(--surface)',
+                                        border: '1px solid var(--border)',
+                                        borderRadius: 'var(--radius-sm)',
+                                        padding: '0.5rem 0.75rem',
+                                        fontSize: 'var(--font-xs)'
+                                    }}>
+                                        <div style={{ fontWeight: 600, marginBottom: 4 }}>{phaseName}</div>
+                                        {items.map((item: any) => (
+                                            <div key={item.dataKey} style={{ display: 'flex', gap: 8, alignItems: 'center', padding: '1px 0' }}>
+                                                <span style={{
+                                                    width: 8, height: 8, borderRadius: '50%',
+                                                    background: item.color, display: 'inline-block', flexShrink: 0
+                                                }}></span>
+                                                <span style={{ flex: 1 }}>{item.dataKey}</span>
+                                                <span style={{ fontWeight: 600 }}>{item.value}.</span>
+                                            </div>
+                                        ))}
+                                    </div>
+                                );
+                            }}
+                        />
+                        {playerNames.map((name) => (
+                            <Line
+                                key={name}
+                                type="monotone"
+                                dataKey={name}
+                                stroke={colorMap.get(name)}
+                                strokeWidth={2}
+                                dot={false}
+                                hide={this.state.hiddenPlayers.has(name)}
+                            />
+                        ))}
+                    </LineChart>
+                </ResponsiveContainer>
+                {/* Inline legend with clickable names */}
+                <div style={{
+                    display: 'flex', flexWrap: 'wrap', gap: '0.35rem 0.75rem',
+                    justifyContent: 'center', marginTop: 'var(--space-sm)', fontSize: 'var(--font-xs)'
+                }}>
+                    {playerNames.map((name) => {
+                        const hidden = this.state.hiddenPlayers.has(name);
+                        return (
+                            <span
+                                key={name}
+                                onClick={() => {
+                                    const next = new Set(this.state.hiddenPlayers);
+                                    if (next.has(name)) { next.delete(name); } else { next.add(name); }
+                                    this.setState({ hiddenPlayers: next });
+                                }}
+                                style={{
+                                    cursor: 'pointer',
+                                    opacity: hidden ? 0.35 : 1,
+                                    display: 'flex', alignItems: 'center', gap: 4,
+                                    textDecoration: hidden ? 'line-through' : 'none'
+                                }}
+                            >
+                                <span style={{
+                                    width: 10, height: 10, borderRadius: '50%',
+                                    background: colorMap.get(name), display: 'inline-block'
+                                }}></span>
+                                {name}
+                            </span>
+                        );
+                    })}
+                </div>
+            </div>
+        );
+    }
+
+}

--- a/ClientApp/src/components/Stats/StatsPage.tsx
+++ b/ClientApp/src/components/Stats/StatsPage.tsx
@@ -1,0 +1,232 @@
+import * as React from 'react';
+import { Api } from '../api/Api';
+import { StatsResponse } from '../../typings';
+import { RankingChart } from './RankingChart';
+import './../../custom.css';
+
+interface StatsPageState {
+    loading: boolean;
+    stats: StatsResponse | null;
+}
+
+export class StatsPage extends React.Component<{}, StatsPageState> {
+    private api = new Api();
+
+    constructor(props: {}) {
+        super(props);
+        this.state = { loading: true, stats: null };
+    }
+
+    componentDidMount() {
+        this.api.getStats().then(stats => {
+            this.setState({ stats, loading: false });
+        }).catch(() => {
+            this.setState({ loading: false });
+        });
+    }
+
+    public render() {
+        const { loading, stats } = this.state;
+
+        if (loading) {
+            return (
+                <div className="stats-page">
+                    <div className="stats-hero">
+                        <h1>Statistiky</h1>
+                    </div>
+                    <div className="skeleton-card">
+                        <div className="skeleton-line"></div>
+                        <div className="skeleton-line"></div>
+                        <div className="skeleton-line"></div>
+                    </div>
+                </div>
+            );
+        }
+
+        if (!stats) {
+            return (
+                <div className="stats-page">
+                    <div className="stats-hero">
+                        <h1>Statistiky</h1>
+                    </div>
+                    <p style={{ textAlign: 'center', color: 'var(--text-muted)' }}>Nepodařilo se načíst statistiky.</p>
+                </div>
+            );
+        }
+
+        return (
+            <div className="stats-page">
+                <div className="stats-hero">
+                    <h1>Statistiky</h1>
+                    <p className="stats-subtitle">Zajímavá čísla z turnaje</p>
+                </div>
+
+                {/* Ranking over time - full width */}
+                <div className="stats-card stats-card-full">
+                    <h2>Vývoj pořadí</h2>
+                    <RankingChart data={stats.rankingOverTime} />
+                </div>
+
+                {/* 2-column grid */}
+                <div className="stats-grid">
+                    {/* Dixit legends */}
+                    <div className="stats-card">
+                        <h2>Dixit legendy</h2>
+                        {stats.dixitLegends.length === 0
+                            ? <p className="stats-empty">Zatím žádné dixity</p>
+                            : <table className="stats-table">
+                                <thead>
+                                    <tr><th>Hráč</th><th>Počet</th></tr>
+                                </thead>
+                                <tbody>
+                                    {stats.dixitLegends.map((d, i) => (
+                                        <tr key={i}><td>{d.userName}</td><td className="stats-value">{d.count}</td></tr>
+                                    ))}
+                                </tbody>
+                            </table>
+                        }
+                    </div>
+
+                    {/* Match no one guessed */}
+                    <div className="stats-card">
+                        <h2>Nikdo netrefil</h2>
+                        {stats.matchNoOneGuessed.length === 0
+                            ? <p className="stats-empty">Všechny zápasy někdo trefil</p>
+                            : <table className="stats-table">
+                                <thead>
+                                    <tr><th>Zápas</th><th>Výsledek</th></tr>
+                                </thead>
+                                <tbody>
+                                    {stats.matchNoOneGuessed.map((m, i) => (
+                                        <tr key={i}>
+                                            <td>
+                                                {m.homeIcon && <img src={m.homeIcon} alt="" width="16" height="16" style={{ marginRight: 4 }} />}
+                                                {m.home} - {m.away}
+                                                {m.awayIcon && <img src={m.awayIcon} alt="" width="16" height="16" style={{ marginLeft: 4 }} />}
+                                            </td>
+                                            <td className="stats-value">{m.result}</td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </table>
+                        }
+                    </div>
+
+                    {/* Biggest upsets */}
+                    <div className="stats-card">
+                        <h2>Největší překvapení</h2>
+                        {stats.biggestUpsets.length === 0
+                            ? <p className="stats-empty">Zatím žádná data</p>
+                            : <table className="stats-table">
+                                <thead>
+                                    <tr><th>Zápas</th><th>Výsledek</th><th>Trefilo</th></tr>
+                                </thead>
+                                <tbody>
+                                    {stats.biggestUpsets.map((m, i) => (
+                                        <tr key={i}>
+                                            <td>
+                                                {m.homeIcon && <img src={m.homeIcon} alt="" width="16" height="16" style={{ marginRight: 4 }} />}
+                                                {m.home} - {m.away}
+                                            </td>
+                                            <td className="stats-value">{m.result}</td>
+                                            <td className="stats-value">{m.correctPercentage}%</td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </table>
+                        }
+                    </div>
+
+                    {/* Most predictable */}
+                    <div className="stats-card">
+                        <h2>Nejpředvídatelnější</h2>
+                        {stats.mostPredictableMatches.length === 0
+                            ? <p className="stats-empty">Zatím žádná data</p>
+                            : <table className="stats-table">
+                                <thead>
+                                    <tr><th>Zápas</th><th>Výsledek</th><th>Trefilo</th></tr>
+                                </thead>
+                                <tbody>
+                                    {stats.mostPredictableMatches.map((m, i) => (
+                                        <tr key={i}>
+                                            <td>
+                                                {m.homeIcon && <img src={m.homeIcon} alt="" width="16" height="16" style={{ marginRight: 4 }} />}
+                                                {m.home} - {m.away}
+                                            </td>
+                                            <td className="stats-value">{m.result}</td>
+                                            <td className="stats-value">{m.correctPercentage}%</td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </table>
+                        }
+                    </div>
+
+                    {/* Joker efficiency */}
+                    <div className="stats-card" style={{ gridColumn: '1 / -1' }}>
+                        <h2>Efektivita jokeru</h2>
+                        {stats.jokerEfficiency.length === 0
+                            ? <p className="stats-empty">Zatím žádné jokery</p>
+                            : <table className="stats-table">
+                                <thead>
+                                    <tr><th>Hráč</th><th>Použito</th><th>Úspěšnost</th><th>Extra body</th></tr>
+                                </thead>
+                                <tbody>
+                                    {stats.jokerEfficiency.map((j, i) => (
+                                        <tr key={i}>
+                                            <td>{j.userName}</td>
+                                            <td className="stats-value">{j.jokersUsed}</td>
+                                            <td className="stats-value">{j.successRate}%</td>
+                                            <td className="stats-value">{j.totalExtraPoints}</td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </table>
+                        }
+                    </div>
+
+                    {/* Exact score heroes */}
+                    <div className="stats-card">
+                        <h2>Přesné výsledky</h2>
+                        {stats.exactScoreHeroes.length === 0
+                            ? <p className="stats-empty">Zatím žádné přesné výsledky</p>
+                            : <table className="stats-table">
+                                <thead>
+                                    <tr><th>Hráč</th><th>Počet</th></tr>
+                                </thead>
+                                <tbody>
+                                    {stats.exactScoreHeroes.map((h, i) => (
+                                        <tr key={i}><td>{h.userName}</td><td className="stats-value">{h.count}</td></tr>
+                                    ))}
+                                </tbody>
+                            </table>
+                        }
+                    </div>
+
+                    {/* Average points per match */}
+                    <div className="stats-card">
+                        <h2>Průměr bodů na zápas</h2>
+                        {stats.averagePointsPerMatch.length === 0
+                            ? <p className="stats-empty">Zatím žádná data</p>
+                            : <table className="stats-table">
+                                <thead>
+                                    <tr><th>Hráč</th><th>Body</th><th>Zápasů</th><th>Průměr</th></tr>
+                                </thead>
+                                <tbody>
+                                    {stats.averagePointsPerMatch.map((a, i) => (
+                                        <tr key={i}>
+                                            <td>{a.userName}</td>
+                                            <td className="stats-value">{a.totalAlfaPoints}</td>
+                                            <td className="stats-value">{a.matchesBetOn}</td>
+                                            <td className="stats-value">{a.average}</td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </table>
+                        }
+                    </div>
+                </div>
+            </div>
+        );
+    }
+}

--- a/ClientApp/src/components/api/Api.ts
+++ b/ClientApp/src/components/api/Api.ts
@@ -1,4 +1,4 @@
-﻿import { MainData, Match, Result, AllBets, Bet, User, UpdateStatus, TournamentStage, GroupBet, Team, Group, DeltaBet, DeltaBetTeams, PlaceTeamBet, TopShooterBet, GroupResult, DeadlineInfo } from "../../typings";
+﻿import { MainData, Match, Result, AllBets, Bet, User, UpdateStatus, TournamentStage, GroupBet, Team, Group, DeltaBet, DeltaBetTeams, PlaceTeamBet, TopShooterBet, GroupResult, DeadlineInfo, StatsResponse } from "../../typings";
 import { IDictionary } from "../../typings/Dictionary";
 import { IApi } from "./IApi";
 import { get, post } from "./HttpClient";
@@ -106,5 +106,9 @@ export class Api implements IApi {
 
     getUpdateStatus(): Promise<UpdateStatus> {
         return convert<UpdateStatus>(get(`${API_URL}/status/`))
+    }
+
+    getStats(): Promise<StatsResponse> {
+        return convert<StatsResponse>(get(`${API_URL}/stats`));
     }
 }

--- a/ClientApp/src/components/api/IApi.d.ts
+++ b/ClientApp/src/components/api/IApi.d.ts
@@ -1,4 +1,4 @@
-import { MainData, Match, Bet, Result, User, UpdateStatus, TournamentStage, GroupBet, Team, Group, DeltaBet, PlaceTeamBet, TopShooterBet, GroupResult, DeadlineInfo } from "../../typings";
+import { MainData, Match, Bet, Result, User, UpdateStatus, TournamentStage, GroupBet, Team, Group, DeltaBet, PlaceTeamBet, TopShooterBet, GroupResult, DeadlineInfo, StatsResponse } from "../../typings";
 import { IDictionary } from "../../typings/Dictionary"
 
 export interface IApi {
@@ -27,4 +27,5 @@ export interface IApi {
     uploadGroupBet(bet: GroupBet, groupId: string): Promise<void>;
     setJoker(matchId: string): Promise<void>;
     getBetsForMatch(matchId: string): Promise<Bet[]>;
+    getStats(): Promise<StatsResponse>;
 }

--- a/ClientApp/src/custom.css
+++ b/ClientApp/src/custom.css
@@ -1666,6 +1666,121 @@ code {
     border-color: var(--primary-light);
 }
 
+/* ===== Stats Page ===== */
+.stats-page {
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 0 1rem 3rem;
+}
+
+.stats-hero {
+    text-align: center;
+    padding: 2.5rem 1rem 1.5rem;
+}
+
+.stats-hero h1 {
+    font-size: 2rem;
+    font-weight: 700;
+    margin-bottom: 0.25rem;
+}
+
+.stats-subtitle {
+    color: var(--text-secondary);
+    font-size: 1.05rem;
+    margin-top: 0;
+}
+
+.stats-card {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: var(--space-lg);
+    box-shadow: var(--shadow-sm);
+    transition: box-shadow var(--transition-normal);
+}
+
+.stats-card:hover {
+    box-shadow: var(--shadow-md);
+}
+
+.stats-card h2 {
+    font-size: var(--font-lg);
+    font-weight: 600;
+    margin-top: 0;
+    margin-bottom: var(--space-md);
+    color: var(--text);
+}
+
+.stats-card-full {
+    margin-bottom: var(--space-lg);
+}
+
+.stats-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(380px, 1fr));
+    gap: 1.25rem;
+}
+
+.stats-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: var(--font-sm);
+}
+
+.stats-table thead th {
+    background: var(--bg);
+    padding: 0.5rem 0.75rem;
+    border-bottom: 2px solid var(--border);
+    font-weight: 600;
+    font-size: var(--font-xs);
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    text-align: left;
+}
+
+.stats-table tbody td {
+    padding: 0.45rem 0.75rem;
+    border-bottom: 1px solid var(--border-light);
+    color: var(--text);
+}
+
+.stats-table tbody tr:last-child td {
+    border-bottom: none;
+}
+
+.stats-table tbody tr:hover {
+    background: var(--bg);
+}
+
+.stats-value {
+    font-weight: 600;
+    text-align: right;
+}
+
+.stats-empty {
+    color: var(--text-muted);
+    font-style: italic;
+    text-align: center;
+    padding: var(--space-md);
+    margin: 0;
+}
+
+@media (max-width: 480px) {
+    .stats-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .stats-table {
+        font-size: var(--font-xs);
+    }
+
+    .stats-table thead th,
+    .stats-table tbody td {
+        padding: 0.35rem 0.5rem;
+    }
+}
+
 /* ===== Mobile Optimizations (Phase 7) ===== */
 @media (max-width: 767.98px) {
     .detail-col {

--- a/ClientApp/src/typings/index.ts
+++ b/ClientApp/src/typings/index.ts
@@ -171,3 +171,67 @@ export interface DeadlineInfo {
     stageDeadlines: { [key: string]: string };
 }
 
+// Stats types
+export interface StatsResponse {
+    rankingOverTime: RankingOverTimeEntry[];
+    matchNoOneGuessed: MatchStatEntry[];
+    exactScoreHeroes: PlayerCountStat[];
+    dixitLegends: PlayerCountStat[];
+    biggestUpsets: MatchPercentageStat[];
+    mostPredictableMatches: MatchPercentageStat[];
+    jokerEfficiency: JokerEfficiencyStat[];
+    averagePointsPerMatch: PlayerAverageStat[];
+}
+
+export interface RankingOverTimeEntry {
+    matchLabel: string;
+    matchStartTime: string;
+    playerPoints: PlayerPointSnapshot[];
+}
+
+export interface PlayerPointSnapshot {
+    userName: string;
+    cumulativePoints: number;
+}
+
+export interface MatchStatEntry {
+    matchId: string;
+    home: string;
+    away: string;
+    homeIcon: string;
+    awayIcon: string;
+    result: string;
+    startTime: string;
+}
+
+export interface PlayerCountStat {
+    userName: string;
+    count: number;
+}
+
+export interface MatchPercentageStat {
+    matchId: string;
+    home: string;
+    away: string;
+    homeIcon: string;
+    awayIcon: string;
+    result: string;
+    correctPercentage: number;
+    totalBets: number;
+}
+
+export interface JokerEfficiencyStat {
+    userName: string;
+    jokersUsed: number;
+    jokersCorrect: number;
+    successRate: number;
+    totalExtraPoints: number;
+}
+
+export interface PlayerAverageStat {
+    userName: string;
+    totalAlfaPoints: number;
+    matchesBetOn: number;
+    average: number;
+}
+

--- a/Controllers/StatsController.cs
+++ b/Controllers/StatsController.cs
@@ -1,0 +1,281 @@
+namespace TipTournament2._0.Controllers
+{
+    using Microsoft.AspNetCore.Authorization;
+    using Microsoft.AspNetCore.Mvc;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using TipTournament2._0.Data;
+    using TipTournament2._0.Models;
+
+    [ApiController]
+    [Authorize]
+    [Route("api/stats")]
+    public class StatsController : Controller
+    {
+        private readonly IDbContextWrapper context;
+
+        public StatsController(IDbContextWrapper context)
+        {
+            this.context = context;
+        }
+
+        [HttpGet]
+        public IActionResult GetStats()
+        {
+            var allBets = this.context.GetAllBetsWithIncludes();
+            var allDeltaBets = this.context.GetAllDeltaBetsWithIncludes();
+            var matches = this.context.GetMatches();
+            var users = this.context.GetAllUsers();
+
+            var endedMatches = matches.Where(m => m.Ended).ToList();
+            var endedMatchIds = new HashSet<string>(endedMatches.Select(m => m.Id));
+            var betsOnEndedMatches = allBets.Where(b => endedMatchIds.Contains(b.Match.Id)).ToList();
+
+            var result = new
+            {
+                RankingOverTime = ComputeRankingOverTime(allBets, allDeltaBets, endedMatches, users),
+                MatchNoOneGuessed = ComputeMatchNoOneGuessed(betsOnEndedMatches, endedMatches),
+                ExactScoreHeroes = ComputeExactScoreHeroes(betsOnEndedMatches),
+                DixitLegends = ComputeDixitLegends(betsOnEndedMatches),
+                BiggestUpsets = ComputeBiggestUpsets(betsOnEndedMatches, endedMatches),
+                MostPredictableMatches = ComputeMostPredictable(betsOnEndedMatches, endedMatches),
+                JokerEfficiency = ComputeJokerEfficiency(betsOnEndedMatches),
+                AveragePointsPerMatch = ComputeAveragePoints(users, betsOnEndedMatches)
+            };
+
+            return new OkObjectResult(result);
+        }
+
+        private static string GetPhaseLabel(Match match)
+        {
+            if (match.Stage == TournamentStage.Group)
+                return $"Kolo {match.Round}";
+
+            switch (match.Stage)
+            {
+                case TournamentStage.FirstRound: return "Osmifinále";
+                case TournamentStage.Quarterfinal: return "Čtvrtfinále";
+                case TournamentStage.Semifinal: return "Semifinále";
+                case TournamentStage.Final: return "Finále";
+                default: return match.Stage.ToString();
+            }
+        }
+
+        private object ComputeRankingOverTime(List<MatchBet> allBets, List<DeltaBet> allDeltaBets, List<Match> endedMatches, List<ApplicationUser> users)
+        {
+            var orderedMatches = endedMatches.OrderBy(m => m.StartTime).ThenBy(m => m.Id).ToList();
+
+            // Group stage match bets by match
+            var matchBetsByMatch = allBets
+                .Where(b => b.Match.Ended)
+                .GroupBy(b => b.Match.Id)
+                .ToDictionary(g => g.Key, g => g.ToList());
+
+            // Delta bets by match (knockout stage)
+            var deltaBetsByMatch = allDeltaBets
+                .Where(b => b.Match != null && b.Match.Ended && b.Result != null)
+                .GroupBy(b => b.Match.Id)
+                .ToDictionary(g => g.Key, g => g.ToList());
+
+            var cumulative = users.ToDictionary(u => u.Id, u => 0);
+            var entries = new List<object>();
+
+            foreach (var match in orderedMatches)
+            {
+                // Add points from group-stage match bets
+                if (matchBetsByMatch.TryGetValue(match.Id, out var matchBets))
+                {
+                    foreach (var bet in matchBets)
+                    {
+                        var points = (int)bet.Result;
+                        if (bet.IsJoker && bet.Result != BetResult.NOTHING)
+                        {
+                            points *= 2;
+                        }
+                        points += bet.DixitBonus;
+
+                        if (cumulative.ContainsKey(bet.User.Id))
+                        {
+                            cumulative[bet.User.Id] += points;
+                        }
+                    }
+                }
+
+                // Add points from delta bets (knockout stage)
+                if (deltaBetsByMatch.TryGetValue(match.Id, out var deltaBets))
+                {
+                    foreach (var bet in deltaBets)
+                    {
+                        var points = bet.Result.Points + bet.DixitBonus;
+                        if (bet.Result.AdditionalResult != null)
+                        {
+                            points += bet.Result.AdditionalResult.Points;
+                        }
+
+                        if (cumulative.ContainsKey(bet.UserId))
+                        {
+                            cumulative[bet.UserId] += points;
+                        }
+                    }
+                }
+
+                entries.Add(new
+                {
+                    MatchLabel = GetPhaseLabel(match),
+                    MatchStartTime = match.StartTime,
+                    PlayerPoints = users.Select(u => new
+                    {
+                        UserName = u.UserName,
+                        CumulativePoints = cumulative.ContainsKey(u.Id) ? cumulative[u.Id] : 0
+                    }).ToList()
+                });
+            }
+
+            return entries;
+        }
+
+        private object ComputeMatchNoOneGuessed(List<MatchBet> betsOnEnded, List<Match> endedMatches)
+        {
+            var matchesWithBets = betsOnEnded
+                .GroupBy(b => b.Match.Id)
+                .Where(g => g.All(b => b.Result == BetResult.NOTHING))
+                .Select(g => g.First().Match)
+                .ToList();
+
+            return matchesWithBets.Select(m => new
+            {
+                MatchId = m.Id,
+                Home = m.Home?.Name,
+                Away = m.Away?.Name,
+                HomeIcon = m.Home?.IconPath,
+                AwayIcon = m.Away?.IconPath,
+                Result = m.Result != null ? $"{m.Result.HomeTeam}:{m.Result.AwayTeam}" : null,
+                StartTime = m.StartTime
+            }).OrderBy(m => m.StartTime).ToList();
+        }
+
+        private object ComputeExactScoreHeroes(List<MatchBet> betsOnEnded)
+        {
+            return betsOnEnded
+                .Where(b => b.Result == BetResult.SCORE)
+                .GroupBy(b => b.User.UserName)
+                .Select(g => new { UserName = g.Key, Count = g.Count() })
+                .OrderByDescending(x => x.Count)
+                .ToList();
+        }
+
+        private object ComputeDixitLegends(List<MatchBet> betsOnEnded)
+        {
+            return betsOnEnded
+                .Where(b => b.DixitBonus == 3)
+                .GroupBy(b => b.User.UserName)
+                .Select(g => new { UserName = g.Key, Count = g.Count() })
+                .OrderByDescending(x => x.Count)
+                .ToList();
+        }
+
+        private object ComputeBiggestUpsets(List<MatchBet> betsOnEnded, List<Match> endedMatches)
+        {
+            return betsOnEnded
+                .GroupBy(b => b.Match.Id)
+                .Select(g =>
+                {
+                    var match = g.First().Match;
+                    var total = g.Count();
+                    var nothingCount = g.Count(b => b.Result == BetResult.NOTHING);
+                    return new
+                    {
+                        MatchId = match.Id,
+                        Home = match.Home?.Name,
+                        Away = match.Away?.Name,
+                        HomeIcon = match.Home?.IconPath,
+                        AwayIcon = match.Away?.IconPath,
+                        Result = match.Result != null ? $"{match.Result.HomeTeam}:{match.Result.AwayTeam}" : null,
+                        CorrectPercentage = Math.Round((double)(total - nothingCount) / total * 100, 1),
+                        TotalBets = total
+                    };
+                })
+                .OrderBy(x => x.CorrectPercentage)
+                .Take(10)
+                .ToList();
+        }
+
+        private object ComputeMostPredictable(List<MatchBet> betsOnEnded, List<Match> endedMatches)
+        {
+            return betsOnEnded
+                .GroupBy(b => b.Match.Id)
+                .Select(g =>
+                {
+                    var match = g.First().Match;
+                    var total = g.Count();
+                    var correctCount = total - g.Count(b => b.Result == BetResult.NOTHING);
+                    return new
+                    {
+                        MatchId = match.Id,
+                        Home = match.Home?.Name,
+                        Away = match.Away?.Name,
+                        HomeIcon = match.Home?.IconPath,
+                        AwayIcon = match.Away?.IconPath,
+                        Result = match.Result != null ? $"{match.Result.HomeTeam}:{match.Result.AwayTeam}" : null,
+                        CorrectPercentage = Math.Round((double)correctCount / total * 100, 1),
+                        TotalBets = total
+                    };
+                })
+                .OrderByDescending(x => x.CorrectPercentage)
+                .Take(10)
+                .ToList();
+        }
+
+        private object ComputeJokerEfficiency(List<MatchBet> betsOnEnded)
+        {
+            var jokerBets = betsOnEnded.Where(b => b.IsJoker).ToList();
+
+            return jokerBets
+                .GroupBy(b => b.User.UserName)
+                .Select(g =>
+                {
+                    var total = g.Count();
+                    var correct = g.Count(b => b.Result != BetResult.NOTHING);
+                    var extraPoints = g.Sum(b =>
+                    {
+                        if (b.Result != BetResult.NOTHING)
+                        {
+                            return (int)b.Result;
+                        }
+                        return 0;
+                    });
+
+                    return new
+                    {
+                        UserName = g.Key,
+                        JokersUsed = total,
+                        JokersCorrect = correct,
+                        SuccessRate = total > 0 ? Math.Round((double)correct / total * 100, 1) : 0,
+                        TotalExtraPoints = extraPoints
+                    };
+                })
+                .OrderByDescending(x => x.TotalExtraPoints)
+                .ToList();
+        }
+
+        private object ComputeAveragePoints(List<ApplicationUser> users, List<MatchBet> betsOnEnded)
+        {
+            var betCountByUser = betsOnEnded
+                .GroupBy(b => b.User.Id)
+                .ToDictionary(g => g.Key, g => g.Count());
+
+            return users
+                .Where(u => betCountByUser.ContainsKey(u.Id) && betCountByUser[u.Id] > 0)
+                .Select(u => new
+                {
+                    UserName = u.UserName,
+                    TotalAlfaPoints = u.AlfaPoints,
+                    MatchesBetOn = betCountByUser[u.Id],
+                    Average = Math.Round((double)u.AlfaPoints / betCountByUser[u.Id], 2)
+                })
+                .OrderByDescending(x => x.Average)
+                .ToList();
+        }
+    }
+}

--- a/Data/DbContextWrapper.cs
+++ b/Data/DbContextWrapper.cs
@@ -620,5 +620,32 @@
                 .Where(b => b.User.Id == userId)
                 .FirstOrDefault();
         }
+
+        public List<MatchBet> GetAllBetsWithIncludes()
+        {
+            return this.dbContext.Bets
+                .Include(b => b.User)
+                .Include(b => b.Match)
+                    .ThenInclude(m => m.Home)
+                .Include(b => b.Match)
+                    .ThenInclude(m => m.Away)
+                .Include(b => b.Match)
+                    .ThenInclude(m => m.Result)
+                .Include(b => b.Tip)
+                .ToList();
+        }
+
+        public List<DeltaBet> GetAllDeltaBetsWithIncludes()
+        {
+            return this.dbContext.DeltaBets
+                .Include(b => b.User)
+                .Include(b => b.Match)
+                    .ThenInclude(m => m.Home)
+                .Include(b => b.Match)
+                    .ThenInclude(m => m.Away)
+                .Include(b => b.Result)
+                    .ThenInclude(r => r.AdditionalResult)
+                .ToList();
+        }
     }
 }

--- a/Data/IDbContextWrapper.cs
+++ b/Data/IDbContextWrapper.cs
@@ -106,5 +106,9 @@
         List<MatchBet> GetBetsForUserAndRound(string userId, int round);
 
         MatchBet GetBetByMatchAndUser(string matchId, string userId);
+
+        List<MatchBet> GetAllBetsWithIncludes();
+
+        List<DeltaBet> GetAllDeltaBetsWithIncludes();
     }
 }


### PR DESCRIPTION
## Summary
- New `/stats` page with ranking-over-time chart and 7 stat tables
- Ranking chart shows player positions (rank) across tournament phases (Kolo 1-3, Osmifinále, etc.) using recharts LineChart with clickable legend and invert button
- Includes both group stage (AlfaPoints) and knockout stage (DeltaPoints) in the chart
- Stat sections: exact score heroes, dixit legends, matches no one guessed, biggest upsets, most predictable matches, joker efficiency, average points per match
- New `StatsController` with `GET /api/stats` endpoint computing all stats server-side
- "Statistiky" nav link added to desktop navbar and mobile drawer

## Test plan
- [x] Navigate to `/stats` — page loads with all 8 stat sections
- [x] Ranking chart renders with player lines showing rank progression
- [x] Hover tooltip shows players sorted by rank with phase name
- [x] Click player names in legend to toggle visibility
- [x] Click "Invertovat výběr" to invert player selection
- [x] Stat tables display correct data
- [ ] Mobile layout works (single column grid, drawer link)

🤖 Generated with [Claude Code](https://claude.com/claude-code)