### PR TITLE
Fix SPA fallback for Azure deployment

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -80,11 +80,13 @@ app.UseStaticFiles();
 
 // In production, serve the React build output from ClientApp/build
 var spaPath = Path.Combine(app.Environment.ContentRootPath, "ClientApp", "build");
+IFileProvider spaFileProvider = null;
 if (Directory.Exists(spaPath))
 {
+    spaFileProvider = new PhysicalFileProvider(spaPath);
     app.UseStaticFiles(new StaticFileOptions
     {
-        FileProvider = new PhysicalFileProvider(spaPath)
+        FileProvider = spaFileProvider
     });
 }
 
@@ -96,6 +98,16 @@ app.MapControllerRoute(
     name: "default",
     pattern: "{controller}/{action=Index}/{id?}");
 app.MapRazorPages();
-app.MapFallbackToFile("index.html");
+if (spaFileProvider != null)
+{
+    app.MapFallbackToFile("index.html", new StaticFileOptions
+    {
+        FileProvider = spaFileProvider
+    });
+}
+else
+{
+    app.MapFallbackToFile("index.html");
+}
 
 app.Run();


### PR DESCRIPTION
## Summary
- Fix 404 on Azure: `MapFallbackToFile("index.html")` was looking in `wwwroot` but SPA files are published to `ClientApp/build`
- Pass the SPA file provider to `MapFallbackToFile` so `index.html` is found in production

## Test plan
- [ ] Deploy to Azure — site loads instead of IIS 404
- [ ] SPA client-side routing works (e.g. `/stats`, `/tips`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)