### PR TITLE
Allow login with username or email

### DIFF
--- a/ClientApp/src/components/api-authorization/Login.js
+++ b/ClientApp/src/components/api-authorization/Login.js
@@ -61,7 +61,7 @@ export class Login extends Component {
                 <h2 className="text-light mb-4">Přihlášení</h2>
                 <form onSubmit={(e) => this.handleLogin(e)}>
                     <div className="form-group mb-3">
-                        <label htmlFor="username">Uživatelské jméno</label>
+                        <label htmlFor="username">Uživatelské jméno nebo email</label>
                         <input
                             type="text"
                             className="form-control"

--- a/Controllers/AuthController.cs
+++ b/Controllers/AuthController.cs
@@ -24,10 +24,24 @@ namespace TipTournament2._0.Controllers
         [AllowAnonymous]
         public async Task<IActionResult> Login([FromBody] LoginRequest request)
         {
-            var result = await _signInManager.PasswordSignInAsync(request.UserName, request.Password, isPersistent: true, lockoutOnFailure: false);
+            if (string.IsNullOrEmpty(request.UserName) || string.IsNullOrEmpty(request.Password))
+            {
+                return BadRequest(new { message = "Neplatné přihlašovací údaje." });
+            }
+
+            // Accept either username or email as login identifier
+            var user = request.UserName.Contains('@')
+                ? await _userManager.FindByEmailAsync(request.UserName)
+                : await _userManager.FindByNameAsync(request.UserName);
+
+            if (user == null)
+            {
+                return BadRequest(new { message = "Neplatné přihlašovací údaje." });
+            }
+
+            var result = await _signInManager.PasswordSignInAsync(user.UserName, request.Password, isPersistent: true, lockoutOnFailure: false);
             if (result.Succeeded)
             {
-                var user = await _userManager.FindByNameAsync(request.UserName);
                 return Ok(new { userName = user.UserName, didPayed = user.Payed });
             }
 


### PR DESCRIPTION
## Summary
- `AuthController.Login`: accept either username or email as the identifier. Input containing `@` is looked up via `FindByEmailAsync`; otherwise via `FindByNameAsync`. The resolved user's `UserName` is then passed to `PasswordSignInAsync`.
- Generic "Neplatné přihlašovací údaje." returned for both bad-username and bad-password to avoid leaking account existence.
- Login form label: "Uživatelské jméno" → "Uživatelské jméno nebo email".

## Test plan
- [x] Existing users can log in with their username (regression check)
- [x] Users can log in with their registered email
- [x] Wrong password with valid username/email returns the generic error
- [x] Unknown username/email returns the same generic error
- [x] Empty username or password returns the same generic error

🤖 Generated with [Claude Code](https://claude.com/claude-code)