### PR TITLE
Add user medals for past tournament winners

### DIFF
--- a/ClientApp/public/medals/bronze-e20.svg
+++ b/ClientApp/public/medals/bronze-e20.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 28" width="24" height="28">
+  <defs>
+    <radialGradient id="bronzeGrad-e20" cx="0.35" cy="0.3">
+      <stop offset="0%" stop-color="#f4c590"/>
+      <stop offset="55%" stop-color="#cd7f32"/>
+      <stop offset="100%" stop-color="#7a4a1a"/>
+    </radialGradient>
+  </defs>
+  <path d="M5 1 L9 12 L4 9 Z" fill="#1976d2"/>
+  <path d="M19 1 L20 9 L15 12 Z" fill="#1976d2"/>
+  <circle cx="12" cy="18" r="9" fill="url(#bronzeGrad-e20)" stroke="#5c3812" stroke-width="0.7"/>
+  <circle cx="12" cy="18" r="9" fill="none" stroke="#f4c590" stroke-width="0.4" stroke-opacity="0.7" stroke-dasharray="0.5 1"/>
+  <text x="12" y="20.3" text-anchor="middle" font-family="'Inter', system-ui, sans-serif" font-size="6.5" font-weight="800" fill="#3d2008">E20</text>
+</svg>

--- a/ClientApp/public/medals/bronze-e24.svg
+++ b/ClientApp/public/medals/bronze-e24.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 28" width="24" height="28">
+  <defs>
+    <radialGradient id="bronzeGrad-e24" cx="0.35" cy="0.3">
+      <stop offset="0%" stop-color="#f4c590"/>
+      <stop offset="55%" stop-color="#cd7f32"/>
+      <stop offset="100%" stop-color="#7a4a1a"/>
+    </radialGradient>
+  </defs>
+  <path d="M5 1 L9 12 L4 9 Z" fill="#dc3545"/>
+  <path d="M19 1 L20 9 L15 12 Z" fill="#dc3545"/>
+  <circle cx="12" cy="18" r="9" fill="url(#bronzeGrad-e24)" stroke="#5c3812" stroke-width="0.7"/>
+  <circle cx="12" cy="18" r="9" fill="none" stroke="#f4c590" stroke-width="0.4" stroke-opacity="0.7" stroke-dasharray="0.5 1"/>
+  <text x="12" y="20.3" text-anchor="middle" font-family="'Inter', system-ui, sans-serif" font-size="6.5" font-weight="800" fill="#3d2008">E24</text>
+</svg>

--- a/ClientApp/public/medals/bronze-wc22.svg
+++ b/ClientApp/public/medals/bronze-wc22.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 28" width="24" height="28">
+  <defs>
+    <radialGradient id="bronzeGrad-wc22" cx="0.35" cy="0.3">
+      <stop offset="0%" stop-color="#f4c590"/>
+      <stop offset="55%" stop-color="#cd7f32"/>
+      <stop offset="100%" stop-color="#7a4a1a"/>
+    </radialGradient>
+  </defs>
+  <path d="M5 1 L9 12 L4 9 Z" fill="#7e1d1d"/>
+  <path d="M19 1 L20 9 L15 12 Z" fill="#7e1d1d"/>
+  <circle cx="12" cy="18" r="9" fill="url(#bronzeGrad-wc22)" stroke="#5c3812" stroke-width="0.7"/>
+  <circle cx="12" cy="18" r="9" fill="none" stroke="#f4c590" stroke-width="0.4" stroke-opacity="0.7" stroke-dasharray="0.5 1"/>
+  <text x="12" y="20.1" text-anchor="middle" font-family="'Inter', system-ui, sans-serif" font-size="5.2" font-weight="800" fill="#3d2008">WC22</text>
+</svg>

--- a/ClientApp/public/medals/gold-e20.svg
+++ b/ClientApp/public/medals/gold-e20.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 28" width="24" height="28">
+  <defs>
+    <radialGradient id="goldGrad-e20" cx="0.35" cy="0.3">
+      <stop offset="0%" stop-color="#fff5b8"/>
+      <stop offset="55%" stop-color="#ffd700"/>
+      <stop offset="100%" stop-color="#b8860b"/>
+    </radialGradient>
+  </defs>
+  <path d="M5 1 L9 12 L4 9 Z" fill="#1976d2"/>
+  <path d="M19 1 L20 9 L15 12 Z" fill="#1976d2"/>
+  <circle cx="12" cy="18" r="9" fill="url(#goldGrad-e20)" stroke="#8b6508" stroke-width="0.7"/>
+  <circle cx="12" cy="18" r="9" fill="none" stroke="#fff7c8" stroke-width="0.4" stroke-opacity="0.7" stroke-dasharray="0.5 1"/>
+  <text x="12" y="20.3" text-anchor="middle" font-family="'Inter', system-ui, sans-serif" font-size="6.5" font-weight="800" fill="#5c4400">E20</text>
+</svg>

--- a/ClientApp/public/medals/gold-e24.svg
+++ b/ClientApp/public/medals/gold-e24.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 28" width="24" height="28">
+  <defs>
+    <radialGradient id="goldGrad-e24" cx="0.35" cy="0.3">
+      <stop offset="0%" stop-color="#fff5b8"/>
+      <stop offset="55%" stop-color="#ffd700"/>
+      <stop offset="100%" stop-color="#b8860b"/>
+    </radialGradient>
+  </defs>
+  <path d="M5 1 L9 12 L4 9 Z" fill="#dc3545"/>
+  <path d="M19 1 L20 9 L15 12 Z" fill="#dc3545"/>
+  <circle cx="12" cy="18" r="9" fill="url(#goldGrad-e24)" stroke="#8b6508" stroke-width="0.7"/>
+  <circle cx="12" cy="18" r="9" fill="none" stroke="#fff7c8" stroke-width="0.4" stroke-opacity="0.7" stroke-dasharray="0.5 1"/>
+  <text x="12" y="20.3" text-anchor="middle" font-family="'Inter', system-ui, sans-serif" font-size="6.5" font-weight="800" fill="#5c4400">E24</text>
+</svg>

--- a/ClientApp/public/medals/gold-wc22.svg
+++ b/ClientApp/public/medals/gold-wc22.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 28" width="24" height="28">
+  <defs>
+    <radialGradient id="goldGrad-wc22" cx="0.35" cy="0.3">
+      <stop offset="0%" stop-color="#fff5b8"/>
+      <stop offset="55%" stop-color="#ffd700"/>
+      <stop offset="100%" stop-color="#b8860b"/>
+    </radialGradient>
+  </defs>
+  <path d="M5 1 L9 12 L4 9 Z" fill="#7e1d1d"/>
+  <path d="M19 1 L20 9 L15 12 Z" fill="#7e1d1d"/>
+  <circle cx="12" cy="18" r="9" fill="url(#goldGrad-wc22)" stroke="#8b6508" stroke-width="0.7"/>
+  <circle cx="12" cy="18" r="9" fill="none" stroke="#fff7c8" stroke-width="0.4" stroke-opacity="0.7" stroke-dasharray="0.5 1"/>
+  <text x="12" y="20.1" text-anchor="middle" font-family="'Inter', system-ui, sans-serif" font-size="5.2" font-weight="800" fill="#5c4400">WC22</text>
+</svg>

--- a/ClientApp/public/medals/silver-e20.svg
+++ b/ClientApp/public/medals/silver-e20.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 28" width="24" height="28">
+  <defs>
+    <radialGradient id="silverGrad-e20" cx="0.35" cy="0.3">
+      <stop offset="0%" stop-color="#ffffff"/>
+      <stop offset="55%" stop-color="#d8d8d8"/>
+      <stop offset="100%" stop-color="#888888"/>
+    </radialGradient>
+  </defs>
+  <path d="M5 1 L9 12 L4 9 Z" fill="#1976d2"/>
+  <path d="M19 1 L20 9 L15 12 Z" fill="#1976d2"/>
+  <circle cx="12" cy="18" r="9" fill="url(#silverGrad-e20)" stroke="#666666" stroke-width="0.7"/>
+  <circle cx="12" cy="18" r="9" fill="none" stroke="#ffffff" stroke-width="0.4" stroke-opacity="0.7" stroke-dasharray="0.5 1"/>
+  <text x="12" y="20.3" text-anchor="middle" font-family="'Inter', system-ui, sans-serif" font-size="6.5" font-weight="800" fill="#3a3a3a">E20</text>
+</svg>

--- a/ClientApp/public/medals/silver-e24.svg
+++ b/ClientApp/public/medals/silver-e24.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 28" width="24" height="28">
+  <defs>
+    <radialGradient id="silverGrad-e24" cx="0.35" cy="0.3">
+      <stop offset="0%" stop-color="#ffffff"/>
+      <stop offset="55%" stop-color="#d8d8d8"/>
+      <stop offset="100%" stop-color="#888888"/>
+    </radialGradient>
+  </defs>
+  <path d="M5 1 L9 12 L4 9 Z" fill="#dc3545"/>
+  <path d="M19 1 L20 9 L15 12 Z" fill="#dc3545"/>
+  <circle cx="12" cy="18" r="9" fill="url(#silverGrad-e24)" stroke="#666666" stroke-width="0.7"/>
+  <circle cx="12" cy="18" r="9" fill="none" stroke="#ffffff" stroke-width="0.4" stroke-opacity="0.7" stroke-dasharray="0.5 1"/>
+  <text x="12" y="20.3" text-anchor="middle" font-family="'Inter', system-ui, sans-serif" font-size="6.5" font-weight="800" fill="#3a3a3a">E24</text>
+</svg>

--- a/ClientApp/public/medals/silver-wc22.svg
+++ b/ClientApp/public/medals/silver-wc22.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 28" width="24" height="28">
+  <defs>
+    <radialGradient id="silverGrad-wc22" cx="0.35" cy="0.3">
+      <stop offset="0%" stop-color="#ffffff"/>
+      <stop offset="55%" stop-color="#d8d8d8"/>
+      <stop offset="100%" stop-color="#888888"/>
+    </radialGradient>
+  </defs>
+  <path d="M5 1 L9 12 L4 9 Z" fill="#7e1d1d"/>
+  <path d="M19 1 L20 9 L15 12 Z" fill="#7e1d1d"/>
+  <circle cx="12" cy="18" r="9" fill="url(#silverGrad-wc22)" stroke="#666666" stroke-width="0.7"/>
+  <circle cx="12" cy="18" r="9" fill="none" stroke="#ffffff" stroke-width="0.4" stroke-opacity="0.7" stroke-dasharray="0.5 1"/>
+  <text x="12" y="20.1" text-anchor="middle" font-family="'Inter', system-ui, sans-serif" font-size="5.2" font-weight="800" fill="#3a3a3a">WC22</text>
+</svg>

--- a/ClientApp/src/components/Admin/UserOverview.tsx
+++ b/ClientApp/src/components/Admin/UserOverview.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import { getAdminApi } from '../api/ApiFactory';
 import { UserRow } from './UserRow'
+import { UserMedal } from '../../typings';
 
 interface AdminUser {
     id: string;
     userName: string;
     payed: boolean;
     isAdmin: boolean;
+    medals: UserMedal[];
 }
 
 interface UserOverviewState {
@@ -41,6 +43,7 @@ export class UserOverview extends React.Component<UserOverviewProps, UserOvervie
                         user={user}
                         onPaymentChange={(payed) => this.handlePaymentChange(user.id, payed)}
                         onAdminChange={(isAdmin) => this.handleAdminChange(user.id, isAdmin)}
+                        onMedalsChange={(medals) => this.handleMedalsChange(user.id, medals)}
                     />
                 ))}
             </div>
@@ -49,7 +52,10 @@ export class UserOverview extends React.Component<UserOverviewProps, UserOvervie
 
     private async getData() {
         const users = await getAdminApi().getUsersWithRoles();
-        this.setState({ users: users, loading: false });
+        this.setState({
+            users: users.map(u => ({ ...u, medals: u.medals || [] })),
+            loading: false
+        });
     }
 
     private handlePaymentChange(userId: string, payed: boolean) {
@@ -61,6 +67,12 @@ export class UserOverview extends React.Component<UserOverviewProps, UserOvervie
     private handleAdminChange(userId: string, isAdmin: boolean) {
         this.setState(prev => ({
             users: prev.users.map(u => u.id === userId ? { ...u, isAdmin } : u)
+        }));
+    }
+
+    private handleMedalsChange(userId: string, medals: UserMedal[]) {
+        this.setState(prev => ({
+            users: prev.users.map(u => u.id === userId ? { ...u, medals } : u)
         }));
     }
 }

--- a/ClientApp/src/components/Admin/UserRow.tsx
+++ b/ClientApp/src/components/Admin/UserRow.tsx
@@ -1,26 +1,44 @@
 import * as React from 'react';
 import { getAdminApi } from "../api/ApiFactory"
 import { ConfirmModal } from './ConfirmModal';
+import { MedalIcon, getMedalLabel } from '../MedalIcon';
+import { MedalTournament, MedalPlace, UserMedal } from '../../typings';
 
 interface AdminUser {
     id: string;
     userName: string;
     payed: boolean;
     isAdmin: boolean;
+    medals: UserMedal[];
 }
 
 interface UserRowState {
     showPayConfirm: boolean;
     showAdminConfirm: boolean;
+    showMedalConfirm: boolean;
     pendingPayValue: boolean;
     pendingAdminValue: boolean;
+    pendingMedal: { tournament: MedalTournament; place: MedalPlace; willAssign: boolean } | null;
 }
 
 interface UserRowProps {
     user: AdminUser;
     onPaymentChange: (payed: boolean) => void;
     onAdminChange: (isAdmin: boolean) => void;
+    onMedalsChange: (medals: UserMedal[]) => void;
 }
+
+const ALL_MEDALS: { tournament: MedalTournament; place: MedalPlace }[] = [
+    { tournament: MedalTournament.E20, place: MedalPlace.Gold },
+    { tournament: MedalTournament.E20, place: MedalPlace.Silver },
+    { tournament: MedalTournament.E20, place: MedalPlace.Bronze },
+    { tournament: MedalTournament.E24, place: MedalPlace.Gold },
+    { tournament: MedalTournament.E24, place: MedalPlace.Silver },
+    { tournament: MedalTournament.E24, place: MedalPlace.Bronze },
+    { tournament: MedalTournament.WC22, place: MedalPlace.Gold },
+    { tournament: MedalTournament.WC22, place: MedalPlace.Silver },
+    { tournament: MedalTournament.WC22, place: MedalPlace.Bronze },
+];
 
 export class UserRow extends React.Component<UserRowProps, UserRowState> {
     constructor(props: UserRowProps) {
@@ -28,8 +46,10 @@ export class UserRow extends React.Component<UserRowProps, UserRowState> {
         this.state = {
             showPayConfirm: false,
             showAdminConfirm: false,
+            showMedalConfirm: false,
             pendingPayValue: false,
             pendingAdminValue: false,
+            pendingMedal: null,
         }
     }
 
@@ -46,6 +66,22 @@ export class UserRow extends React.Component<UserRowProps, UserRowState> {
                     <span className={`admin-role-badge ${user.isAdmin ? 'admin-role-badge-admin' : 'admin-role-badge-user'}`}>
                         {user.isAdmin ? 'Admin' : 'Uzivatel'}
                     </span>
+                </div>
+                <div className="admin-user-medals">
+                    {ALL_MEDALS.map(m => {
+                        const isAssigned = this.hasMedal(m.tournament, m.place);
+                        return (
+                            <button
+                                key={`${m.tournament}-${m.place}`}
+                                type="button"
+                                className={`admin-medal-chip ${isAssigned ? 'admin-medal-chip-on' : 'admin-medal-chip-off'}`}
+                                title={getMedalLabel(m.tournament, m.place) + (isAssigned ? ' (kliknutim odebrat)' : ' (kliknutim pridat)')}
+                                onClick={() => this.requestMedalToggle(m.tournament, m.place, !isAssigned)}
+                            >
+                                <MedalIcon tournament={m.tournament} place={m.place} size={22} />
+                            </button>
+                        );
+                    })}
                 </div>
                 <div className="admin-user-actions">
                     {user.payed
@@ -81,8 +117,24 @@ export class UserRow extends React.Component<UserRowProps, UserRowState> {
                         onCancel={() => this.setState({ showAdminConfirm: false })}
                     />
                 }
+                {this.state.showMedalConfirm && this.state.pendingMedal &&
+                    <ConfirmModal
+                        title="Zmena medaile"
+                        message={this.state.pendingMedal.willAssign
+                            ? `Pridat medaili "${getMedalLabel(this.state.pendingMedal.tournament, this.state.pendingMedal.place)}" uzivateli "${user.userName}"?`
+                            : `Odebrat medaili "${getMedalLabel(this.state.pendingMedal.tournament, this.state.pendingMedal.place)}" uzivateli "${user.userName}"?`}
+                        variant={this.state.pendingMedal.willAssign ? 'warning' : 'danger'}
+                        confirmText={this.state.pendingMedal.willAssign ? 'Pridat' : 'Odebrat'}
+                        onConfirm={() => this.confirmMedalToggle()}
+                        onCancel={() => this.setState({ showMedalConfirm: false, pendingMedal: null })}
+                    />
+                }
             </div>
         );
+    }
+
+    private hasMedal(tournament: MedalTournament, place: MedalPlace): boolean {
+        return (this.props.user.medals || []).some(m => m.tournament === tournament && m.place === place);
     }
 
     private requestPayChange(payed: boolean) {
@@ -105,5 +157,21 @@ export class UserRow extends React.Component<UserRowProps, UserRowState> {
         this.setState({ showAdminConfirm: false });
         await getAdminApi().setAdmin(this.props.user.id, isAdmin);
         this.props.onAdminChange(isAdmin);
+    }
+
+    private requestMedalToggle(tournament: MedalTournament, place: MedalPlace, willAssign: boolean) {
+        this.setState({ showMedalConfirm: true, pendingMedal: { tournament, place, willAssign } });
+    }
+
+    private async confirmMedalToggle() {
+        const pending = this.state.pendingMedal;
+        if (!pending) return;
+        this.setState({ showMedalConfirm: false, pendingMedal: null });
+        const result = await getAdminApi().toggleMedal(this.props.user.id, pending.tournament, pending.place);
+        const current = this.props.user.medals || [];
+        const updated = result.assigned
+            ? [...current, { tournament: pending.tournament, place: pending.place }]
+            : current.filter(m => !(m.tournament === pending.tournament && m.place === pending.place));
+        this.props.onMedalsChange(updated);
     }
 }

--- a/ClientApp/src/components/MainPage/UserRow.tsx
+++ b/ClientApp/src/components/MainPage/UserRow.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { User } from "../../typings/index"
 import { NavLink } from 'reactstrap';
 import { Link } from 'react-router-dom';
+import { MedalIcon } from '../MedalIcon';
 
 interface UserRowProps {
     user: User,
@@ -21,7 +22,10 @@ export class UserRow extends React.Component<UserRowProps> {
         return (
             <React.Fragment>
                 <td className={className}>
-                    {beforeLimit ? <div className={this.getTextClassName()}>{this.getContent()}</div> : <NavLink tag={Link} className={this.getTextClassName()} to={this.getLink()}>{this.getContent()}</NavLink>}
+                    <div className="ranking-name-cell">
+                        {beforeLimit ? <div className={this.getTextClassName()}>{this.getContent()}</div> : <NavLink tag={Link} className={this.getTextClassName()} to={this.getLink()}>{this.getContent()}</NavLink>}
+                        {this.renderMedals()}
+                    </div>
                 </td>
                 <td className="detail-col">{this.props.user.alfaPoints}</td>
                 <td className="detail-col">{this.props.user.gamaPoints}</td>
@@ -30,6 +34,18 @@ export class UserRow extends React.Component<UserRowProps> {
                 <td className="detail-col">{this.props.user.omikronPoints}</td>
                 <td className="font-weight-bold">{this.props.user.totalPoints}</td>
             </React.Fragment>
+        );
+    }
+
+    private renderMedals() {
+        const medals = this.props.user.medals;
+        if (!medals || medals.length === 0) return null;
+        return (
+            <span className="ranking-medals">
+                {medals.map((m, i) => (
+                    <MedalIcon key={`${m.tournament}-${m.place}-${i}`} tournament={m.tournament} place={m.place} size={20} />
+                ))}
+            </span>
         );
     }
 

--- a/ClientApp/src/components/MedalIcon.tsx
+++ b/ClientApp/src/components/MedalIcon.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import { MedalTournament, MedalPlace } from '../typings';
+
+interface MedalIconProps {
+    tournament: MedalTournament;
+    place: MedalPlace;
+    size?: number;
+    className?: string;
+    title?: string;
+}
+
+const TOURNAMENT_KEY: Record<MedalTournament, string> = {
+    [MedalTournament.E20]: 'e20',
+    [MedalTournament.E24]: 'e24',
+    [MedalTournament.WC22]: 'wc22'
+};
+
+const PLACE_KEY: Record<MedalPlace, string> = {
+    [MedalPlace.Gold]: 'gold',
+    [MedalPlace.Silver]: 'silver',
+    [MedalPlace.Bronze]: 'bronze'
+};
+
+const TOURNAMENT_LABEL: Record<MedalTournament, string> = {
+    [MedalTournament.E20]: 'EURO 2020',
+    [MedalTournament.E24]: 'EURO 2024',
+    [MedalTournament.WC22]: 'World Cup 2022'
+};
+
+const PLACE_LABEL: Record<MedalPlace, string> = {
+    [MedalPlace.Gold]: 'Zlato',
+    [MedalPlace.Silver]: 'Stříbro',
+    [MedalPlace.Bronze]: 'Bronz'
+};
+
+export function getMedalIconPath(tournament: MedalTournament, place: MedalPlace): string {
+    return `${process.env.PUBLIC_URL}/medals/${PLACE_KEY[place]}-${TOURNAMENT_KEY[tournament]}.svg`;
+}
+
+export function getMedalLabel(tournament: MedalTournament, place: MedalPlace): string {
+    return `${PLACE_LABEL[place]} – ${TOURNAMENT_LABEL[tournament]}`;
+}
+
+export class MedalIcon extends React.Component<MedalIconProps> {
+    public render() {
+        const size = this.props.size || 22;
+        const title = this.props.title || getMedalLabel(this.props.tournament, this.props.place);
+        return (
+            <img
+                src={getMedalIconPath(this.props.tournament, this.props.place)}
+                width={size}
+                height={Math.round(size * 28 / 24)}
+                alt={title}
+                title={title}
+                className={`medal-icon ${this.props.className || ''}`}
+            />
+        );
+    }
+}

--- a/ClientApp/src/components/RulePage.tsx
+++ b/ClientApp/src/components/RulePage.tsx
@@ -38,13 +38,13 @@ export class RulePage extends React.Component<RulePageProps> {
                             <li>V menu klikni na <strong>Sázky</strong></li>
                             <li>Vyplň všechny tipovací sekce</li>
                             <li>Body se sčítají po každém odehraném zápase</li>
-                            <li>Zaplatit startovné 200 Kč (QR kód níže)</li>
+                            <li>Zaplatit startovné 300 Kč (QR kód níže)</li>
                         </ol>
                     </div>
                     <div className="rules-card">
                         <div className="rules-card-icon">&#128176;</div>
                         <h2>Startovné</h2>
-                        <p>Startovné je <strong>200 Kč</strong>. Do předmětu platby napiš svoje uživatelské jméno.</p>
+                        <p>Startovné je <strong>300 Kč</strong>. Do předmětu platby napiš svoje uživatelské jméno.</p>
                         <div className="rules-qr">
                             <img src={process.env.PUBLIC_URL + '/icons/QR.jpg'} width="160" height="160" alt="QR Code pro platbu" />
                         </div>

--- a/ClientApp/src/components/api/AdminApi.ts
+++ b/ClientApp/src/components/api/AdminApi.ts
@@ -41,4 +41,8 @@ export class AdminApi implements IAdminApi {
     getUsersWithRoles(): Promise<any[]> {
         return convert<any[]>(get(`${API_URL}/users`));
     }
+
+    toggleMedal(userId: string, tournament: number, place: number): Promise<{ assigned: boolean }> {
+        return convert<{ assigned: boolean }>(post(`${API_URL}/${userId}/medal`, { tournament, place }));
+    }
 }

--- a/ClientApp/src/components/api/IAdminApi.d.ts
+++ b/ClientApp/src/components/api/IAdminApi.d.ts
@@ -20,4 +20,6 @@ export interface IAdminApi {
     setAdmin(userId: string, isAdmin: boolean): Promise<void>;
 
     getUsersWithRoles(): Promise<any[]>;
+
+    toggleMedal(userId: string, tournament: number, place: number): Promise<{ assigned: boolean }>;
 }

--- a/ClientApp/src/custom.css
+++ b/ClientApp/src/custom.css
@@ -951,6 +951,14 @@ code {
     white-space: nowrap;
 }
 
+.ranking-table thead th.detail-col,
+.ranking-table tbody td.detail-col {
+    padding-left: 0.4rem;
+    padding-right: 0.4rem;
+    text-align: center;
+    width: 1%;
+}
+
 .ranking-table thead th a {
     color: var(--text-secondary);
     text-decoration: none;
@@ -2238,6 +2246,45 @@ select option {
     flex-shrink: 0;
 }
 
+.admin-user-medals {
+    display: flex;
+    gap: 0.25rem;
+    flex-wrap: wrap;
+    flex-shrink: 0;
+}
+
+.admin-medal-chip {
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: var(--radius-sm);
+    padding: 2px;
+    cursor: pointer;
+    line-height: 0;
+    transition: opacity var(--transition-fast), border-color var(--transition-fast), background var(--transition-fast);
+}
+
+.admin-medal-chip-off {
+    opacity: 0.32;
+    filter: grayscale(0.6);
+}
+
+.admin-medal-chip-off:hover {
+    opacity: 0.7;
+    filter: grayscale(0.3);
+    background: rgba(255, 255, 255, 0.05);
+}
+
+.admin-medal-chip-on {
+    opacity: 1;
+    border-color: rgba(255, 255, 255, 0.25);
+    background: rgba(255, 255, 255, 0.08);
+}
+
+.admin-medal-chip-on:hover {
+    border-color: var(--danger);
+    background: var(--danger-bg);
+}
+
 @media (max-width: 767.98px) {
     .admin-user-row {
         flex-wrap: wrap;
@@ -2251,6 +2298,30 @@ select option {
         width: 100%;
         justify-content: flex-end;
     }
+
+    .admin-user-medals {
+        width: 100%;
+    }
+}
+
+/* ===== Medals (ranking display) ===== */
+.medal-icon {
+    vertical-align: middle;
+    flex-shrink: 0;
+}
+
+.ranking-name-cell {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    flex-wrap: nowrap;
+    white-space: nowrap;
+}
+
+.ranking-medals {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.15rem;
 }
 
 .admin-role-badge {

--- a/ClientApp/src/typings/index.ts
+++ b/ClientApp/src/typings/index.ts
@@ -82,6 +82,24 @@ export interface User {
     lambdaPoints: number;
     omikronPoints: number;
     payed: boolean;
+    medals?: UserMedal[];
+}
+
+export enum MedalTournament {
+    E20 = 0,
+    E24 = 1,
+    WC22 = 2
+}
+
+export enum MedalPlace {
+    Gold = 0,
+    Silver = 1,
+    Bronze = 2
+}
+
+export interface UserMedal {
+    tournament: MedalTournament;
+    place: MedalPlace;
 }
 
 export interface AllBets {

--- a/Controllers/AdminController.cs
+++ b/Controllers/AdminController.cs
@@ -136,20 +136,44 @@
         public async Task<IActionResult> GetUsersWithRoles()
         {
             var users = this.context.GetUsers();
+            var medalsByUser = this.context.GetMedalsForUsers(users.Select(u => u.Id));
             var result = new List<object>();
             foreach (var user in users)
             {
                 var roles = await this.userManager.GetRolesAsync(user);
+                medalsByUser.TryGetValue(user.Id, out var medals);
                 result.Add(new
                 {
                     id = user.Id,
                     userName = user.UserName,
                     payed = user.Payed,
-                    isAdmin = roles.Contains("Admin")
+                    isAdmin = roles.Contains("Admin"),
+                    medals = (medals ?? new List<UserMedal>())
+                        .Select(m => new { tournament = m.Tournament, place = m.Place })
+                        .ToList()
                 });
             }
 
             return new OkObjectResult(result);
         }
+
+        [HttpPost("{userId}/medal")]
+        public async Task<IActionResult> ToggleMedal([FromRoute] string userId, [FromBody] ToggleMedalRequest request)
+        {
+            var user = await this.userManager.FindByIdAsync(userId);
+            if (user == null)
+            {
+                return NotFound();
+            }
+
+            var assigned = this.context.ToggleUserMedal(userId, request.Tournament, request.Place);
+            return new OkObjectResult(new { assigned });
+        }
+    }
+
+    public class ToggleMedalRequest
+    {
+        public Tournament Tournament { get; set; }
+        public MedalPlace Place { get; set; }
     }
 }

--- a/Controllers/HomeController.cs
+++ b/Controllers/HomeController.cs
@@ -25,16 +25,25 @@
         [HttpGet("users")]
         public IActionResult GetUsers([FromQuery] bool orderByPoints)
         {
-            return orderByPoints
-                ? new OkObjectResult(this.context.GetAllUsers().Select(u => UiUser.FromApplicationUser(u))
+            var users = this.context.GetAllUsers();
+            var medalsByUser = this.context.GetMedalsForUsers(users.Select(u => u.Id));
+            var uiUsers = users
+                .Select(u => UiUser.FromApplicationUser(u, medalsByUser.TryGetValue(u.Id, out var ms) ? ms : null))
+                .ToList();
+
+            if (orderByPoints)
+            {
+                uiUsers = uiUsers
                     .OrderByDescending(u => u.TotalPoints)
                     .ThenByDescending(u => u.AlfaPoints)
                     .ThenByDescending(u => u.GamaPoints)
                     .ThenByDescending(u => u.DeltaPoints)
                     .ThenByDescending(u => u.LambdaPoints)
                     .ThenByDescending(u => u.OmikronPoints)
-                .ToList())
-                : new OkObjectResult(this.context.GetAllUsers().Select(u => UiUser.FromApplicationUser(u)).ToList());
+                    .ToList();
+            }
+
+            return new OkObjectResult(uiUsers);
         }
 
         [HttpGet("user/payed")]

--- a/Data/ApplicationDbContext.cs
+++ b/Data/ApplicationDbContext.cs
@@ -38,6 +38,8 @@ namespace TipTournament2._0.Data
 
         public DbSet<DeltaBetResult> DeltaBetResults { get; set; }
 
+        public DbSet<UserMedal> UserMedals { get; set; }
+
         public ApplicationDbContext(DbContextOptions options) : base(options)
         {
         }

--- a/Data/DbContextWrapper.cs
+++ b/Data/DbContextWrapper.cs
@@ -647,5 +647,45 @@
                     .ThenInclude(r => r.AdditionalResult)
                 .ToList();
         }
+
+        public List<UserMedal> GetMedalsForUser(string userId)
+        {
+            return this.dbContext.UserMedals.Where(m => m.UserId == userId).ToList();
+        }
+
+        public Dictionary<string, List<UserMedal>> GetMedalsForUsers(IEnumerable<string> userIds)
+        {
+            var ids = userIds.ToList();
+            return this.dbContext.UserMedals
+                .Where(m => ids.Contains(m.UserId))
+                .ToList()
+                .GroupBy(m => m.UserId)
+                .ToDictionary(g => g.Key, g => g.ToList());
+        }
+
+        // Adds the medal if it doesn't exist for this (user, tournament, place) triple, otherwise removes it.
+        // Returns true if the medal is now assigned, false if it was removed.
+        public bool ToggleUserMedal(string userId, Tournament tournament, MedalPlace place)
+        {
+            var existing = this.dbContext.UserMedals
+                .FirstOrDefault(m => m.UserId == userId && m.Tournament == tournament && m.Place == place);
+
+            if (existing != null)
+            {
+                this.dbContext.UserMedals.Remove(existing);
+                this.dbContext.SaveChanges();
+                return false;
+            }
+
+            this.dbContext.UserMedals.Add(new UserMedal
+            {
+                Id = Guid.NewGuid().ToString(),
+                UserId = userId,
+                Tournament = tournament,
+                Place = place
+            });
+            this.dbContext.SaveChanges();
+            return true;
+        }
     }
 }

--- a/Data/IDbContextWrapper.cs
+++ b/Data/IDbContextWrapper.cs
@@ -110,5 +110,11 @@
         List<MatchBet> GetAllBetsWithIncludes();
 
         List<DeltaBet> GetAllDeltaBetsWithIncludes();
+
+        List<UserMedal> GetMedalsForUser(string userId);
+
+        Dictionary<string, List<UserMedal>> GetMedalsForUsers(IEnumerable<string> userIds);
+
+        bool ToggleUserMedal(string userId, Tournament tournament, MedalPlace place);
     }
 }

--- a/Data/Migrations/20260510202629_AddUserMedals.Designer.cs
+++ b/Data/Migrations/20260510202629_AddUserMedals.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TipTournament2._0.Data;
 
@@ -11,9 +12,11 @@ using TipTournament2._0.Data;
 namespace TipTournament2._0.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260510202629_AddUserMedals")]
+    partial class AddUserMedals
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Data/Migrations/20260510202629_AddUserMedals.cs
+++ b/Data/Migrations/20260510202629_AddUserMedals.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TipTournament2._0.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserMedals : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "UserMedals",
+                columns: table => new
+                {
+                    Id = table.Column<string>(type: "nvarchar(450)", nullable: false),
+                    UserId = table.Column<string>(type: "nvarchar(max)", nullable: false),
+                    Tournament = table.Column<int>(type: "int", nullable: false),
+                    Place = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserMedals", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "UserMedals");
+        }
+    }
+}

--- a/Models/UiUser.cs
+++ b/Models/UiUser.cs
@@ -25,7 +25,9 @@
 
         public bool Payed { get; set; }
 
-        public static UiUser FromApplicationUser(ApplicationUser appUser)
+        public List<UiUserMedal> Medals { get; set; } = new List<UiUserMedal>();
+
+        public static UiUser FromApplicationUser(ApplicationUser appUser, List<UserMedal> medals = null)
         {
             return new UiUser()
             {
@@ -37,8 +39,17 @@
                 DeltaPoints = appUser.DeltaPoints,
                 LambdaPoints = appUser.LambdaPoints,
                 OmikronPoints = appUser.OmikronPoints,
-                Payed = appUser.Payed
+                Payed = appUser.Payed,
+                Medals = (medals ?? new List<UserMedal>())
+                    .Select(m => new UiUserMedal { Tournament = m.Tournament, Place = m.Place })
+                    .ToList()
             };
         }
+    }
+
+    public class UiUserMedal
+    {
+        public Tournament Tournament { get; set; }
+        public MedalPlace Place { get; set; }
     }
 }

--- a/Models/UserMedal.cs
+++ b/Models/UserMedal.cs
@@ -1,0 +1,34 @@
+namespace TipTournament2._0.Models
+{
+    using System.ComponentModel.DataAnnotations;
+    using System.ComponentModel.DataAnnotations.Schema;
+
+    public class UserMedal
+    {
+        [Key]
+        public string Id { get; set; }
+
+        [Required]
+        public string UserId { get; set; }
+
+        [Required]
+        public Tournament Tournament { get; set; }
+
+        [Required]
+        public MedalPlace Place { get; set; }
+    }
+
+    public enum Tournament
+    {
+        E20 = 0,
+        E24 = 1,
+        WC22 = 2
+    }
+
+    public enum MedalPlace
+    {
+        Gold = 0,
+        Silver = 1,
+        Bronze = 2
+    }
+}


### PR DESCRIPTION
## Summary
Admins can assign Gold/Silver/Bronze medals from three past tournaments — EURO 2020 (E20), EURO 2024 (E24), World Cup 2022 (WC22) — to any user. Medals appear inline next to usernames on the ranking page.

### Backend
- `Models/UserMedal.cs` with `Tournament` and `MedalPlace` enums (0/1/2)
- EF migration `AddUserMedals` (`UserMedals` table); applied to dev DB
- `IDbContextWrapper`: `GetMedalsForUser`, `GetMedalsForUsers` (batch), `ToggleUserMedal` (returns true if assigned, false if removed)
- `AdminController`: `POST /api/admin/{userId}/medal { tournament, place }` toggles; `GET /api/admin/users` now includes `medals[]` per user
- `HomeController.GetUsers` populates `UiUser.Medals` via the batch lookup (no N+1)

### Frontend
- 9 SVG icons under `ClientApp/public/medals/` — circular medal disc with tournament tag inside and a small ribbon in a tournament-themed color (E20 blue, E24 red, WC22 dark red)
- New `MedalIcon` component with helpers (`getMedalIconPath`, `getMedalLabel`)
- Admin `UserRow`: row of 9 chip toggles, full-color when assigned, faded/grayscaled when not, click → confirmation modal → toggle
- Main page `UserRow` (ranking): medals render inline next to the username with a Czech-localized tooltip
- Stat columns tightened (`width: 1%`, smaller horizontal padding) and `.ranking-name-cell` uses `flex-wrap: nowrap` so long usernames + multiple medals stay on one line

### Misc
- Bumped startovné `200 Kč` → `300 Kč` in rules

## Test plan
- [x] Admin user list: each row shows 9 medal chips (3 metals × 3 tournaments). Faded when not assigned, full-color when assigned.
- [ ] Click a chip → confirmation modal → confirm → chip flips state and persists across reload.
- [x] Ranking page: assigned medals appear inline next to username; tooltip shows "Zlato/Stříbro/Bronz – tournament name".
- [x] Long usernames + multiple medals stay on a single line in the ranking.
- [x] Users with no medals render exactly as before (regression).
- [x] Backend: a user can hold multiple medals; the same `(user, tournament, place)` triple cannot be duplicated (toggle removes instead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)