### PR TITLE
Bracket Reality block + winner pick fix + drop 3rd-place row

### DIFF
--- a/ClientApp/src/components/Admin/AdminMatchView.tsx
+++ b/ClientApp/src/components/Admin/AdminMatchView.tsx
@@ -180,7 +180,9 @@ export class AdminMatchView extends React.Component<AdminMatchViewProps, AdminMa
                         <div className="card-body">
                             <div className="groupList">
                                 {
-                                    this.state.matches.filter(m => m.stage == TournamentStage.Semifinal).map(m => {
+                                    // match_103 = 3rd-place playoff; sits at Semifinal stage in legacy DBs
+                                    // but isn't part of the betting bracket. Hide it here.
+                                    this.state.matches.filter(m => m.stage == TournamentStage.Semifinal && m.id !== 'match_103').map(m => {
                                         return <DeltaBetAdminViewRow key={m.id} match={m} />
                                     })
                                 }

--- a/ClientApp/src/components/Admin/WinnerAdminView.tsx
+++ b/ClientApp/src/components/Admin/WinnerAdminView.tsx
@@ -47,7 +47,7 @@ export class WinnerAdminViewRow extends React.Component<WinnerAdminViewRowProps,
     }
 
     private async getData() {
-        const deltaTeams = await getAdminApi().getTeamForMatch("match_51", TournamentStage.Winner);
+        const deltaTeams = await getAdminApi().getTeamForMatch("match_104", TournamentStage.Winner);
         const teams = [];
         if (deltaTeams.possibleHomeTeams?.length > 0) {
             teams.push(deltaTeams.possibleHomeTeams[0]);
@@ -110,7 +110,7 @@ export class WinnerAdminViewRow extends React.Component<WinnerAdminViewRowProps,
 
     private async confirm(): Promise<void> {
         this.setState({ showConfirm: false });
-        await getAdminApi().setWinner("match_51", this.state.winner);
+        await getAdminApi().setWinner("match_104", this.state.winner);
         this.setState({ evaluated: true });
     }
 }

--- a/ClientApp/src/components/Bets/DeltaBetRow.tsx
+++ b/ClientApp/src/components/Bets/DeltaBetRow.tsx
@@ -157,20 +157,43 @@ export class DeltaBetRow extends React.Component<DeltaBetProps, DeltaBetState> {
                         {this.getTotalPointsWithBonus()}b
                     </div>
                 )}
-                {this.props.showResult && (this.props.match.home || this.props.match.away) && (
+                {this.shouldShowActual() && (
                     <div className="delta-compact-actual">
-                        <span className="delta-compact-actual-label">Skutečně:</span>
-                        {this.props.match.home
-                            ? <><img src={process.env.PUBLIC_URL + this.props.match.home.iconPath} width="14" height="14" alt={this.props.match.home.name} /><span>{this.props.match.home.name}</span></>
-                            : <span className="delta-compact-tbd">TBD</span>}
-                        <span className="delta-compact-actual-vs">vs</span>
-                        {this.props.match.away
-                            ? <><img src={process.env.PUBLIC_URL + this.props.match.away.iconPath} width="14" height="14" alt={this.props.match.away.name} /><span>{this.props.match.away.name}</span></>
-                            : <span className="delta-compact-tbd">TBD</span>}
+                        <div className="delta-compact-actual-label">Skutečnost:</div>
+                        <div className="delta-compact-team">
+                            {this.props.match.home
+                                ? <>
+                                    <img src={process.env.PUBLIC_URL + this.props.match.home.iconPath} width="18" height="18" alt={this.props.match.home.name} />
+                                    <span>{this.props.match.home.name}</span>
+                                  </>
+                                : <span className="delta-compact-tbd">TBD</span>}
+                        </div>
+                        <div className="delta-compact-team">
+                            {this.props.match.away
+                                ? <>
+                                    <img src={process.env.PUBLIC_URL + this.props.match.away.iconPath} width="18" height="18" alt={this.props.match.away.name} />
+                                    <span>{this.props.match.away.name}</span>
+                                  </>
+                                : <span className="delta-compact-tbd">TBD</span>}
+                        </div>
                     </div>
                 )}
             </div>
         );
+    }
+
+    private shouldShowActual(): boolean {
+        if (!this.props.showResult) return false;
+        const home = this.props.match.home;
+        const away = this.props.match.away;
+        if (!home && !away) return false;
+        const betHome = this.state.bet.homeTeamBet;
+        const betAway = this.state.bet.awayTeamBet;
+        const homeMatches = !!home && !!betHome && home.id === betHome.id;
+        const awayMatches = !!away && !!betAway && away.id === betAway.id;
+        // Hide when the user already nailed both sides
+        if (homeMatches && awayMatches) return false;
+        return true;
     }
 
     private renderCompactEditable() {

--- a/ClientApp/src/custom.css
+++ b/ClientApp/src/custom.css
@@ -1463,28 +1463,25 @@ code {
 
 .delta-compact-actual {
     display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 0.25rem;
-    margin-top: 0.25rem;
-    padding-top: 0.25rem;
+    flex-direction: column;
+    gap: 0.15rem;
+    margin-top: 0.3rem;
+    padding-top: 0.3rem;
     border-top: 1px dashed rgba(255, 255, 255, 0.15);
-    font-size: 0.65rem;
     color: var(--text-secondary);
-    line-height: 1.2;
 }
 
 .delta-compact-actual-label {
+    font-size: 0.65rem;
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.03em;
     color: var(--text-muted);
-    margin-right: 0.15rem;
+    margin-bottom: 0.1rem;
 }
 
-.delta-compact-actual-vs {
-    color: var(--text-muted);
-    margin: 0 0.15rem;
+.delta-compact-actual .delta-compact-team {
+    color: var(--text-secondary);
 }
 
 /* ===== Tournament Bracket ===== */

--- a/Scripts/populate-wc2026.sql
+++ b/Scripts/populate-wc2026.sql
@@ -210,10 +210,8 @@ INSERT INTO Matches (Id, HomeId, AwayId, StartTime, Ended, Stage, Round) VALUES
 ('match_101', NULL, NULL, '2026-07-14 19:00:00', 0, 4, 0),  -- W97 vs W98, Arlington UTC-5 → 14:00+5=19:00
 ('match_102', NULL, NULL, '2026-07-15 19:00:00', 0, 4, 0);  -- W99 vs W100, Atlanta UTC-4 → 15:00+4=19:00
 
--- Third place match (treated as Semifinal stage in app)
-INSERT INTO Matches (Id, HomeId, AwayId, StartTime, Ended, Stage, Round) VALUES
-('match_103', NULL, NULL, '2026-07-18 21:00:00', 0, 4, 0);  -- L101 vs L102, Miami UTC-4 → 17:00+4=21:00
-
 -- Final
+-- (Third-place playoff intentionally omitted - the betting bracket only covers
+--  Semifinal winners advancing to the Final; loser placement does not affect scoring.)
 INSERT INTO Matches (Id, HomeId, AwayId, StartTime, Ended, Stage, Round) VALUES
 ('match_104', NULL, NULL, '2026-07-19 19:00:00', 0, 5, 0);  -- W101 vs W102, East Rutherford UTC-4 → 15:00+4=19:00


### PR DESCRIPTION
## Summary

Three small fixes the user surfaced while end-to-end testing the admin/bet flow:

- **Bracket Reality block restyled** — in the main-page bracket (`DeltaBetRow.renderCompact`), the "actual teams" footer now mirrors the bet layout above it: two stacked rows of \`icon + name\` under a "Skutečnost:" label. Hidden entirely when both bet teams already match the actual ones, so correct picks stay clean.
- **Winner admin uses the right match** — `WinnerAdminView` was hardcoded to \`match_51\` (a group-stage match), so the dropdown surfaced unrelated teams. Switched to \`match_104\` (the actual Final) so it correctly pulls the two finalists.
- **3rd-place playoff row gone** — \`match_103\` sits at Semifinal stage in legacy DBs but isn't part of the betting bracket (no entry in the \`DeltaStage:Next\` config). It showed up as an empty third Semifinal row in admin. Now filtered out in the admin UI, and removed from the populate script for fresh DBs.

## Reminder

There's also a one-off DB fix (not in this PR — needs to run against the live DB once):
\`\`\`sql
UPDATE Teams SET Name = N'Česko' WHERE Id = 'czechia';
\`\`\`
The populate script already has the diacritics correct; this only catches stale data in already-seeded DBs.

## Test plan
- [x] Main page → bracket: pick a R16/QF/SF/F match where one of your bet teams differs from the admin-set actual; you should see a "Skutečnost:" block under your bet with two stacked rows (icon + name).
- [x] Main page → bracket: pick a match where both your bet teams match the actual; the Skutečnost block should NOT appear.
- [x] Admin → Vítěz: dropdown shows the two finalists (whoever's set into match_104), no random teams.
- [x] Admin → Semifinále: shows exactly two rows (match_101 and match_102), no empty third row.
- [x] Fresh DB seeded via \`Scripts/populate-wc2026.sql\` does not contain match_103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)