### PR TITLE
Password recovery via plaintext recovery codes (no email pipeline)

### DIFF
--- a/ClientApp/src/components/Admin/UserOverview.tsx
+++ b/ClientApp/src/components/Admin/UserOverview.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { getAdminApi } from '../api/ApiFactory';
 import { UserRow } from './UserRow'
 import { UserMedal } from '../../typings';
+import { ConfirmModal } from './ConfirmModal';
 
 interface AdminUser {
     id: string;
@@ -9,11 +10,14 @@ interface AdminUser {
     payed: boolean;
     isAdmin: boolean;
     medals: UserMedal[];
+    recoveryCode?: string | null;
 }
 
 interface UserOverviewState {
     loading: boolean;
     users: AdminUser[];
+    showBulkConfirm: boolean;
+    bulkResult: { userName: string; email: string; recoveryCode: string }[] | null;
 }
 
 interface UserOverviewProps {
@@ -23,7 +27,7 @@ export class UserOverview extends React.Component<UserOverviewProps, UserOvervie
 
     constructor(props: UserOverviewProps) {
         super(props);
-        this.state = { loading: true, users: [] }
+        this.state = { loading: true, users: [], showBulkConfirm: false, bulkResult: null }
     }
 
     public componentDidMount() {
@@ -35,17 +39,84 @@ export class UserOverview extends React.Component<UserOverviewProps, UserOvervie
             return <p style={{ color: 'var(--text-muted)' }}>Nacitam uzivatele...</p>;
         }
 
+        const missingCount = this.state.users.filter(u => !u.recoveryCode).length;
+
         return (
-            <div className="admin-user-list">
-                {this.state.users.map((user) => (
-                    <UserRow
-                        key={user.id}
-                        user={user}
-                        onPaymentChange={(payed) => this.handlePaymentChange(user.id, payed)}
-                        onAdminChange={(isAdmin) => this.handleAdminChange(user.id, isAdmin)}
-                        onMedalsChange={(medals) => this.handleMedalsChange(user.id, medals)}
+            <div>
+                {missingCount > 0 && (
+                    <div className="admin-bulk-bar">
+                        <span>{missingCount} uzivatelu bez zachranneho kodu.</span>
+                        <button
+                            className="btn btn-sm btn-primary"
+                            onClick={() => this.setState({ showBulkConfirm: true })}
+                        >
+                            Vygenerovat chybejici kody
+                        </button>
+                    </div>
+                )}
+                {this.state.bulkResult && this.renderBulkResult()}
+                <div className="admin-user-list">
+                    {this.state.users.map((user) => (
+                        <UserRow
+                            key={user.id}
+                            user={user}
+                            onPaymentChange={(payed) => this.handlePaymentChange(user.id, payed)}
+                            onAdminChange={(isAdmin) => this.handleAdminChange(user.id, isAdmin)}
+                            onMedalsChange={(medals) => this.handleMedalsChange(user.id, medals)}
+                            onRecoveryCodeChange={(code) => this.handleRecoveryCodeChange(user.id, code)}
+                        />
+                    ))}
+                </div>
+                {this.state.showBulkConfirm && (
+                    <ConfirmModal
+                        title="Vygenerovat chybejici zachranne kody"
+                        message={`Vygenerovat zachranny kod pro vsechny uzivatele, kteri zadny nemaji (${missingCount})? Po vygenerovani je uvidis tady a pak je rozeslej mailem.`}
+                        variant="warning"
+                        confirmText="Vygenerovat"
+                        onConfirm={() => this.confirmBulk()}
+                        onCancel={() => this.setState({ showBulkConfirm: false })}
                     />
-                ))}
+                )}
+            </div>
+        );
+    }
+
+    private renderBulkResult() {
+        if (!this.state.bulkResult) return null;
+        return (
+            <div className="admin-bulk-result">
+                <div className="admin-bulk-result-header">
+                    <strong>{this.state.bulkResult.length} kodu vygenerovano</strong>
+                    <button
+                        className="btn btn-sm btn-outline-secondary"
+                        onClick={() => {
+                            const text = (this.state.bulkResult || []).map(r => `${r.userName}\t${r.email}\t${r.recoveryCode}`).join('\n');
+                            navigator.clipboard?.writeText(text);
+                        }}
+                    >
+                        Zkopirovat vse (TSV)
+                    </button>
+                    <button
+                        className="btn btn-sm btn-link"
+                        onClick={() => this.setState({ bulkResult: null })}
+                    >
+                        Zavrit
+                    </button>
+                </div>
+                <table className="admin-bulk-table">
+                    <thead>
+                        <tr><th>Uzivatel</th><th>Email</th><th>Kod</th></tr>
+                    </thead>
+                    <tbody>
+                        {this.state.bulkResult.map(r => (
+                            <tr key={r.userName}>
+                                <td>{r.userName}</td>
+                                <td>{r.email}</td>
+                                <td><code>{r.recoveryCode}</code></td>
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
             </div>
         );
     }
@@ -56,6 +127,19 @@ export class UserOverview extends React.Component<UserOverviewProps, UserOvervie
             users: users.map(u => ({ ...u, medals: u.medals || [] })),
             loading: false
         });
+    }
+
+    private async confirmBulk() {
+        this.setState({ showBulkConfirm: false });
+        const generated = await getAdminApi().generateMissingRecoveryCodes();
+        // Fold the new codes into the user list state
+        this.setState(prev => ({
+            users: prev.users.map(u => {
+                const match = generated.find(g => g.userName === u.userName);
+                return match ? { ...u, recoveryCode: match.recoveryCode } : u;
+            }),
+            bulkResult: generated
+        }));
     }
 
     private handlePaymentChange(userId: string, payed: boolean) {
@@ -73,6 +157,12 @@ export class UserOverview extends React.Component<UserOverviewProps, UserOvervie
     private handleMedalsChange(userId: string, medals: UserMedal[]) {
         this.setState(prev => ({
             users: prev.users.map(u => u.id === userId ? { ...u, medals } : u)
+        }));
+    }
+
+    private handleRecoveryCodeChange(userId: string, code: string) {
+        this.setState(prev => ({
+            users: prev.users.map(u => u.id === userId ? { ...u, recoveryCode: code } : u)
         }));
     }
 }

--- a/ClientApp/src/components/Admin/UserRow.tsx
+++ b/ClientApp/src/components/Admin/UserRow.tsx
@@ -10,12 +10,14 @@ interface AdminUser {
     payed: boolean;
     isAdmin: boolean;
     medals: UserMedal[];
+    recoveryCode?: string | null;
 }
 
 interface UserRowState {
     showPayConfirm: boolean;
     showAdminConfirm: boolean;
     showMedalConfirm: boolean;
+    showRegenConfirm: boolean;
     pendingPayValue: boolean;
     pendingAdminValue: boolean;
     pendingMedal: { tournament: MedalTournament; place: MedalPlace; willAssign: boolean } | null;
@@ -26,6 +28,7 @@ interface UserRowProps {
     onPaymentChange: (payed: boolean) => void;
     onAdminChange: (isAdmin: boolean) => void;
     onMedalsChange: (medals: UserMedal[]) => void;
+    onRecoveryCodeChange: (code: string) => void;
 }
 
 const ALL_MEDALS: { tournament: MedalTournament; place: MedalPlace }[] = [
@@ -47,6 +50,7 @@ export class UserRow extends React.Component<UserRowProps, UserRowState> {
             showPayConfirm: false,
             showAdminConfirm: false,
             showMedalConfirm: false,
+            showRegenConfirm: false,
             pendingPayValue: false,
             pendingAdminValue: false,
             pendingMedal: null,
@@ -82,6 +86,22 @@ export class UserRow extends React.Component<UserRowProps, UserRowState> {
                             </button>
                         );
                     })}
+                </div>
+                <div className="admin-user-recovery">
+                    <code
+                        className="admin-recovery-code"
+                        title={user.recoveryCode ? 'Kliknutim zkopirovat' : 'Zadny zachranny kod'}
+                        onClick={() => user.recoveryCode && navigator.clipboard?.writeText(user.recoveryCode)}
+                    >
+                        {user.recoveryCode || '— bez kódu —'}
+                    </code>
+                    <button
+                        className="btn btn-sm btn-outline-secondary"
+                        onClick={() => this.setState({ showRegenConfirm: true })}
+                        title="Vygenerovat novy zachranny kod"
+                    >
+                        ⟳
+                    </button>
                 </div>
                 <div className="admin-user-actions">
                     {user.payed
@@ -129,8 +149,24 @@ export class UserRow extends React.Component<UserRowProps, UserRowState> {
                         onCancel={() => this.setState({ showMedalConfirm: false, pendingMedal: null })}
                     />
                 }
+                {this.state.showRegenConfirm &&
+                    <ConfirmModal
+                        title="Novy zachranny kod"
+                        message={`Vygenerovat novy zachranny kod pro "${user.userName}"? Stary kod prestane platit.`}
+                        variant="warning"
+                        confirmText="Vygenerovat"
+                        onConfirm={() => this.confirmRegen()}
+                        onCancel={() => this.setState({ showRegenConfirm: false })}
+                    />
+                }
             </div>
         );
+    }
+
+    private async confirmRegen() {
+        this.setState({ showRegenConfirm: false });
+        const result = await getAdminApi().regenerateRecoveryCode(this.props.user.id);
+        this.props.onRecoveryCodeChange(result.recoveryCode);
     }
 
     private hasMedal(tournament: MedalTournament, place: MedalPlace): boolean {

--- a/ClientApp/src/components/api-authorization/ApiAuthorizationConstants.js
+++ b/ClientApp/src/components/api-authorization/ApiAuthorizationConstants.js
@@ -13,7 +13,8 @@ export const LogoutActions = {
 export const LoginActions = {
   Login: 'login',
   LoginFailed: 'login-failed',
-  Register: 'register'
+  Register: 'register',
+  Recovery: 'recovery'
 };
 
 const prefix = '/authentication';
@@ -24,6 +25,7 @@ export const ApplicationPaths = {
   Login: `${prefix}/${LoginActions.Login}`,
   LoginFailed: `${prefix}/${LoginActions.LoginFailed}`,
   Register: `${prefix}/${LoginActions.Register}`,
+  Recovery: `${prefix}/${LoginActions.Recovery}`,
   LogOut: `${prefix}/${LogoutActions.Logout}`,
   LoggedOut: `${prefix}/${LogoutActions.LoggedOut}`
 };

--- a/ClientApp/src/components/api-authorization/ApiAuthorizationRoutes.js
+++ b/ClientApp/src/components/api-authorization/ApiAuthorizationRoutes.js
@@ -12,6 +12,7 @@ export default class ApiAuthorizationRoutes extends Component {
           <Route path={ApplicationPaths.Login} render={() => loginAction(LoginActions.Login)} />
           <Route path={ApplicationPaths.LoginFailed} render={() => loginAction(LoginActions.LoginFailed)} />
           <Route path={ApplicationPaths.Register} render={() => loginAction(LoginActions.Register)} />
+          <Route path={ApplicationPaths.Recovery} render={() => loginAction(LoginActions.Recovery)} />
           <Route path={ApplicationPaths.LogOut} render={() => logoutAction(LogoutActions.Logout)} />
           <Route path={ApplicationPaths.LoggedOut} render={() => logoutAction(LogoutActions.LoggedOut)} />
       </Fragment>);

--- a/ClientApp/src/components/api-authorization/Login.js
+++ b/ClientApp/src/components/api-authorization/Login.js
@@ -12,18 +12,17 @@ export class Login extends Component {
             message: undefined,
             email: '',
             password: '',
+            recoveryCode: '',
             isLoading: false,
-            action: props.action
+            action: props.action,
+            generatedRecoveryCode: undefined,
+            redirectAfterSave: '/'
         };
     }
 
     componentDidMount() {
         const action = this.props.action;
-        if (action === LoginActions.Login) {
-            // Show login form
-        } else if (action === LoginActions.Register) {
-            this.setState({ action: LoginActions.Register });
-        } else if (action === LoginActions.LoginFailed) {
+        if (action === LoginActions.LoginFailed) {
             const params = new URLSearchParams(window.location.search);
             const error = params.get(QueryParameterNames.Message);
             this.setState({ message: error });
@@ -31,9 +30,13 @@ export class Login extends Component {
     }
 
     render() {
-        const { message, action } = this.state;
+        const { message, action, generatedRecoveryCode } = this.state;
 
-        if (!!message) {
+        if (generatedRecoveryCode) {
+            return this.renderRecoveryCodeSavePrompt();
+        }
+
+        if (!!message && action !== LoginActions.Login && action !== LoginActions.Register && action !== LoginActions.Recovery) {
             return <div>{message}</div>
         }
 
@@ -41,11 +44,15 @@ export class Login extends Component {
             return this.renderRegisterForm();
         }
 
+        if (action === LoginActions.Recovery) {
+            return this.renderRecoveryForm();
+        }
+
         return this.renderLoginForm();
     }
 
     renderLoginForm() {
-        const { email, password, isLoading } = this.state;
+        const { email, password, isLoading, message } = this.state;
 
         if (isLoading) {
             return (
@@ -58,7 +65,8 @@ export class Login extends Component {
 
         return (
             <div className="container" style={{ maxWidth: '400px', marginTop: '50px' }}>
-                <h2 className="text-light mb-4">Přihlášení</h2>
+                <h2 className="mb-4">Přihlášení</h2>
+                {message && <div className="alert alert-danger" role="alert">{message}</div>}
                 <form onSubmit={(e) => this.handleLogin(e)}>
                     <div className="form-group mb-3">
                         <label htmlFor="username">Uživatelské jméno nebo email</label>
@@ -84,12 +92,15 @@ export class Login extends Component {
                     </div>
                     <button type="submit" className="btn btn-primary w-100">Přihlásit se</button>
                 </form>
+                <div className="mt-3 text-center">
+                    <a href={ApplicationPaths.Recovery}>Zapomněl jsi heslo? Použij záchranný kód</a>
+                </div>
             </div>
         );
     }
 
     renderRegisterForm() {
-        const { email, password, isLoading } = this.state;
+        const { email, password, isLoading, message } = this.state;
 
         if (isLoading) {
             return (
@@ -102,7 +113,8 @@ export class Login extends Component {
 
         return (
             <div className="container" style={{ maxWidth: '400px', marginTop: '50px' }}>
-                <h2 className="text-light mb-4">Registrace</h2>
+                <h2 className="mb-4">Registrace</h2>
+                {message && <div className="alert alert-danger" role="alert">{message}</div>}
                 <form onSubmit={(e) => this.handleRegister(e)}>
                     <div className="form-group mb-3">
                         <label htmlFor="email">Email</label>
@@ -128,6 +140,114 @@ export class Login extends Component {
                     </div>
                     <button type="submit" className="btn btn-primary w-100">Registrovat se</button>
                 </form>
+            </div>
+        );
+    }
+
+    renderRecoveryForm() {
+        const { email, recoveryCode, password, isLoading, message } = this.state;
+
+        if (isLoading) {
+            return (
+                <div className="justify-content-center">
+                    <p className="display-4">Obnovuju heslo...</p>
+                    <Loader />
+                </div>
+            );
+        }
+
+        return (
+            <div className="container" style={{ maxWidth: '440px', marginTop: '50px' }}>
+                <h2 className="mb-2">Obnova hesla</h2>
+                <p className="text-muted mb-4">
+                    Zadej svůj email (nebo uživatelské jméno), záchranný kód a nové heslo. Záchranný kód jsi dostal mailem od admina (nebo při registraci).
+                </p>
+                {message && <div className="alert alert-danger" role="alert">{message}</div>}
+                <form onSubmit={(e) => this.handleRecovery(e)}>
+                    <div className="form-group mb-3">
+                        <label htmlFor="rec-email">Email nebo uživatelské jméno</label>
+                        <input
+                            type="text"
+                            className="form-control"
+                            id="rec-email"
+                            value={email}
+                            onChange={(e) => this.setState({ email: e.target.value })}
+                            autoComplete="username"
+                            required
+                        />
+                    </div>
+                    <div className="form-group mb-3">
+                        <label htmlFor="rec-code">Záchranný kód</label>
+                        <input
+                            type="text"
+                            className="form-control"
+                            id="rec-code"
+                            placeholder="tip-XXXX-XXXX-XXXX"
+                            value={recoveryCode}
+                            onChange={(e) => this.setState({ recoveryCode: e.target.value.trim() })}
+                            autoComplete="off"
+                            spellCheck="false"
+                            required
+                        />
+                    </div>
+                    <div className="form-group mb-3">
+                        <label htmlFor="rec-new-password">Nové heslo</label>
+                        <input
+                            type="password"
+                            className="form-control"
+                            id="rec-new-password"
+                            value={password}
+                            onChange={(e) => this.setState({ password: e.target.value })}
+                            autoComplete="new-password"
+                            required
+                        />
+                    </div>
+                    <button type="submit" className="btn btn-primary w-100">Nastavit nové heslo</button>
+                </form>
+                <div className="mt-3 text-center">
+                    <a href={ApplicationPaths.Login}>Zpátky na přihlášení</a>
+                </div>
+            </div>
+        );
+    }
+
+    renderRecoveryCodeSavePrompt() {
+        const { generatedRecoveryCode, redirectAfterSave } = this.state;
+        return (
+            <div className="container" style={{ maxWidth: '480px', marginTop: '50px' }}>
+                <h2 className="mb-3">Záchranný kód</h2>
+                <div className="alert alert-warning" role="alert">
+                    <strong>Ulož si tento kód!</strong> Pokud zapomeneš heslo, pomocí tohoto kódu si ho budeš moct obnovit. Bez něj ztratíš účet. Nikomu ho nedávej.
+                </div>
+                <div className="form-control mb-3" style={{
+                    fontFamily: 'monospace',
+                    fontSize: '1.4rem',
+                    textAlign: 'center',
+                    fontWeight: 700,
+                    padding: '0.85rem',
+                    letterSpacing: '0.05em',
+                    cursor: 'text'
+                }}>
+                    {generatedRecoveryCode}
+                </div>
+                <div className="d-flex" style={{ gap: '0.5rem' }}>
+                    <button
+                        type="button"
+                        className="btn btn-outline-secondary"
+                        onClick={() => {
+                            navigator.clipboard?.writeText(generatedRecoveryCode);
+                        }}
+                    >
+                        Zkopírovat
+                    </button>
+                    <button
+                        type="button"
+                        className="btn btn-primary flex-grow-1"
+                        onClick={() => window.location.replace(redirectAfterSave)}
+                    >
+                        Mám to uložené, pokračovat
+                    </button>
+                </div>
             </div>
         );
     }
@@ -171,9 +291,15 @@ export class Login extends Component {
             });
 
             if (response.ok) {
+                const data = await response.json();
                 authService._user = null;
                 authService.notifySubscribers();
-                window.location.replace('/');
+                // Show recovery code first; the "continue" button redirects.
+                this.setState({
+                    isLoading: false,
+                    generatedRecoveryCode: data.recoveryCode,
+                    redirectAfterSave: '/'
+                });
             } else {
                 const data = await response.json();
                 const errorMsg = data.errors
@@ -183,6 +309,39 @@ export class Login extends Component {
             }
         } catch (error) {
             this.setState({ message: 'Chyba při registraci.', isLoading: false });
+        }
+    }
+
+    async handleRecovery(e) {
+        e.preventDefault();
+        this.setState({ isLoading: true, message: undefined });
+
+        try {
+            const response = await fetch('/api/auth/recovery/reset', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                credentials: 'same-origin',
+                body: JSON.stringify({
+                    email: this.state.email,
+                    recoveryCode: this.state.recoveryCode,
+                    newPassword: this.state.password
+                })
+            });
+
+            if (response.ok) {
+                authService._user = null;
+                authService.notifySubscribers();
+                const returnUrl = this.getReturnUrl();
+                window.location.replace(returnUrl);
+            } else {
+                const data = await response.json();
+                const errorMsg = data.errors
+                    ? data.errors.map(e => e.description).join(' ')
+                    : (data.message || 'Obnova hesla se nezdařila.');
+                this.setState({ message: errorMsg, isLoading: false });
+            }
+        } catch (error) {
+            this.setState({ message: 'Chyba při obnově hesla.', isLoading: false });
         }
     }
 

--- a/ClientApp/src/components/api/AdminApi.ts
+++ b/ClientApp/src/components/api/AdminApi.ts
@@ -45,4 +45,14 @@ export class AdminApi implements IAdminApi {
     toggleMedal(userId: string, tournament: number, place: number): Promise<{ assigned: boolean }> {
         return convert<{ assigned: boolean }>(post(`${API_URL}/${userId}/medal`, { tournament, place }));
     }
+
+    generateMissingRecoveryCodes(): Promise<{ userName: string; email: string; recoveryCode: string }[]> {
+        return convert<{ userName: string; email: string; recoveryCode: string }[]>(
+            post(`${API_URL}/recovery-codes/missing`)
+        );
+    }
+
+    regenerateRecoveryCode(userId: string): Promise<{ recoveryCode: string }> {
+        return convert<{ recoveryCode: string }>(post(`${API_URL}/${userId}/recovery-code`));
+    }
 }

--- a/ClientApp/src/components/api/IAdminApi.d.ts
+++ b/ClientApp/src/components/api/IAdminApi.d.ts
@@ -22,4 +22,8 @@ export interface IAdminApi {
     getUsersWithRoles(): Promise<any[]>;
 
     toggleMedal(userId: string, tournament: number, place: number): Promise<{ assigned: boolean }>;
+
+    generateMissingRecoveryCodes(): Promise<{ userName: string; email: string; recoveryCode: string }[]>;
+
+    regenerateRecoveryCode(userId: string): Promise<{ recoveryCode: string }>;
 }

--- a/ClientApp/src/custom.css
+++ b/ClientApp/src/custom.css
@@ -2399,6 +2399,95 @@ select option {
     flex-shrink: 0;
 }
 
+.admin-user-recovery {
+    display: flex;
+    align-items: center;
+    gap: var(--space-xs);
+    flex-shrink: 0;
+}
+
+.admin-recovery-code {
+    font-family: 'Inter', monospace;
+    font-size: var(--font-xs);
+    font-weight: 600;
+    color: var(--text-secondary);
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: var(--radius-sm);
+    padding: 0.2rem 0.5rem;
+    cursor: pointer;
+    letter-spacing: 0.03em;
+    user-select: all;
+}
+
+.admin-recovery-code:hover {
+    background: rgba(255, 255, 255, 0.1);
+    color: var(--text);
+}
+
+.admin-bulk-bar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-md);
+    padding: var(--space-sm) var(--space-md);
+    margin-bottom: var(--space-md);
+    background: var(--warning-bg);
+    border: 1px solid var(--warning);
+    border-radius: var(--radius-md);
+    color: var(--text);
+    font-size: var(--font-sm);
+}
+
+.admin-bulk-result {
+    background: var(--glass-bg);
+    backdrop-filter: blur(var(--glass-blur));
+    -webkit-backdrop-filter: blur(var(--glass-blur));
+    border: var(--glass-border);
+    border-radius: var(--radius-md);
+    padding: var(--space-md);
+    margin-bottom: var(--space-md);
+}
+
+.admin-bulk-result-header {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    justify-content: space-between;
+    flex-wrap: wrap;
+    margin-bottom: var(--space-sm);
+}
+
+.admin-bulk-table {
+    width: 100%;
+    font-size: var(--font-sm);
+    border-collapse: collapse;
+}
+
+.admin-bulk-table thead th {
+    text-align: left;
+    padding: 0.35rem 0.6rem;
+    border-bottom: 1px solid var(--border-light);
+    color: var(--text-secondary);
+    font-weight: 700;
+    font-size: var(--font-xs);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.admin-bulk-table tbody td {
+    padding: 0.35rem 0.6rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.admin-bulk-table tbody td code {
+    font-weight: 700;
+    color: var(--primary-lighter);
+    background: rgba(66, 153, 225, 0.12);
+    padding: 0.1rem 0.4rem;
+    border-radius: var(--radius-sm);
+}
+
 .admin-user-medals {
     display: flex;
     gap: 0.25rem;

--- a/Controllers/AdminController.cs
+++ b/Controllers/AdminController.cs
@@ -13,6 +13,7 @@
     using TipTournament2._0.Models;
     using TipTournament2._0.Utils;
 
+
     [ApiController]
     [Authorize(Roles = "Admin")]
     [Route("api/admin")]
@@ -148,6 +149,7 @@
                     userName = user.UserName,
                     payed = user.Payed,
                     isAdmin = roles.Contains("Admin"),
+                    recoveryCode = user.RecoveryCode,
                     medals = (medals ?? new List<UserMedal>())
                         .Select(m => new { tournament = m.Tournament, place = m.Place })
                         .ToList()
@@ -168,6 +170,41 @@
 
             var assigned = this.context.ToggleUserMedal(userId, request.Tournament, request.Place);
             return new OkObjectResult(new { assigned });
+        }
+
+        // Generates recovery codes for any user who doesn't have one yet.
+        // Returns the per-user plaintext codes so admin can email them out.
+        // Idempotent: users with existing codes are skipped.
+        [HttpPost("recovery-codes/missing")]
+        public async Task<IActionResult> GenerateMissingRecoveryCodes()
+        {
+            var users = this.context.GetUsers();
+            var generated = new List<object>();
+            foreach (var user in users)
+            {
+                if (string.IsNullOrEmpty(user.RecoveryCode))
+                {
+                    user.RecoveryCode = RecoveryCodeGenerator.Generate();
+                    await this.userManager.UpdateAsync(user);
+                    generated.Add(new { userName = user.UserName, email = user.Email, recoveryCode = user.RecoveryCode });
+                }
+            }
+            return new OkObjectResult(generated);
+        }
+
+        // Regenerates a single user's recovery code (overwrites the existing one).
+        [HttpPost("{userId}/recovery-code")]
+        public async Task<IActionResult> RegenerateRecoveryCode([FromRoute] string userId)
+        {
+            var user = await this.userManager.FindByIdAsync(userId);
+            if (user == null)
+            {
+                return NotFound();
+            }
+
+            user.RecoveryCode = RecoveryCodeGenerator.Generate();
+            await this.userManager.UpdateAsync(user);
+            return new OkObjectResult(new { recoveryCode = user.RecoveryCode });
         }
     }
 

--- a/Controllers/AuthController.cs
+++ b/Controllers/AuthController.cs
@@ -6,6 +6,7 @@ namespace TipTournament2._0.Controllers
     using System.Linq;
     using System.Threading.Tasks;
     using TipTournament2._0.Models;
+    using TipTournament2._0.Utils;
 
     [Route("api/[controller]")]
     [ApiController]
@@ -86,15 +87,75 @@ namespace TipTournament2._0.Controllers
         [AllowAnonymous]
         public async Task<IActionResult> Register([FromBody] RegisterRequest request)
         {
-            var user = new ApplicationUser { UserName = request.Email, Email = request.Email };
+            var user = new ApplicationUser
+            {
+                UserName = request.Email,
+                Email = request.Email,
+                RecoveryCode = RecoveryCodeGenerator.Generate()
+            };
             var result = await _userManager.CreateAsync(user, request.Password);
             if (result.Succeeded)
             {
                 await _signInManager.SignInAsync(user, isPersistent: true);
-                return Ok(new { userName = user.UserName, didPayed = user.Payed });
+                return Ok(new
+                {
+                    userName = user.UserName,
+                    didPayed = user.Payed,
+                    recoveryCode = user.RecoveryCode
+                });
             }
 
             return BadRequest(new { errors = result.Errors });
+        }
+
+        [HttpPost("recovery/reset")]
+        [AllowAnonymous]
+        public async Task<IActionResult> RecoveryReset([FromBody] RecoveryResetRequest request)
+        {
+            if (string.IsNullOrEmpty(request.Email)
+                || string.IsNullOrEmpty(request.RecoveryCode)
+                || string.IsNullOrEmpty(request.NewPassword))
+            {
+                return BadRequest(new { message = "Neplatné údaje." });
+            }
+
+            // Accept either email or username. Try email first (most users
+            // will type that), fall back to username — handles legacy accounts
+            // where NormalizedEmail may not be set.
+            var user = await _userManager.FindByEmailAsync(request.Email);
+            if (user == null)
+            {
+                user = await _userManager.FindByNameAsync(request.Email);
+            }
+            if (user == null)
+            {
+                // Last-resort case-insensitive scan against raw Email/UserName,
+                // for accounts where the Identity normalized fields are stale.
+                user = _userManager.Users.FirstOrDefault(u =>
+                    (u.Email != null && u.Email.ToLower() == request.Email.ToLower())
+                    || (u.UserName != null && u.UserName.ToLower() == request.Email.ToLower()));
+            }
+
+            if (user == null
+                || string.IsNullOrEmpty(user.RecoveryCode)
+                || !string.Equals(user.RecoveryCode, request.RecoveryCode, System.StringComparison.Ordinal))
+            {
+                return BadRequest(new { message = "Neplatné údaje." });
+            }
+
+            var removeResult = await _userManager.RemovePasswordAsync(user);
+            if (!removeResult.Succeeded)
+            {
+                return BadRequest(new { errors = removeResult.Errors });
+            }
+            var addResult = await _userManager.AddPasswordAsync(user, request.NewPassword);
+            if (!addResult.Succeeded)
+            {
+                return BadRequest(new { errors = addResult.Errors });
+            }
+
+            await _signInManager.SignInAsync(user, isPersistent: true);
+            return Ok(new { userName = user.UserName, didPayed = user.Payed });
         }
     }
 
@@ -108,5 +169,12 @@ namespace TipTournament2._0.Controllers
     {
         public string Email { get; set; }
         public string Password { get; set; }
+    }
+
+    public class RecoveryResetRequest
+    {
+        public string Email { get; set; }
+        public string RecoveryCode { get; set; }
+        public string NewPassword { get; set; }
     }
 }

--- a/Data/Migrations/20260514182156_AddRecoveryCodeToUser.Designer.cs
+++ b/Data/Migrations/20260514182156_AddRecoveryCodeToUser.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TipTournament2._0.Data;
 
@@ -11,9 +12,11 @@ using TipTournament2._0.Data;
 namespace TipTournament2._0.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260514182156_AddRecoveryCodeToUser")]
+    partial class AddRecoveryCodeToUser
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Data/Migrations/20260514182156_AddRecoveryCodeToUser.cs
+++ b/Data/Migrations/20260514182156_AddRecoveryCodeToUser.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TipTournament2._0.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddRecoveryCodeToUser : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "RecoveryCode",
+                table: "AspNetUsers",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "RecoveryCode",
+                table: "AspNetUsers");
+        }
+    }
+}

--- a/Models/ApplicationUser.cs
+++ b/Models/ApplicationUser.cs
@@ -21,5 +21,10 @@
         public int OmikronPoints { get; set; }
 
         public bool Payed { get; set; }
+
+        // Plain-text recovery code for password reset. Admin can read this from
+        // the admin UI and share it with users (no email pipeline). Acceptable
+        // tradeoff for a small private friend pool — see auth flow design.
+        public string RecoveryCode { get; set; }
     }
 }

--- a/Utils/RecoveryCodeGenerator.cs
+++ b/Utils/RecoveryCodeGenerator.cs
@@ -1,0 +1,39 @@
+namespace TipTournament2._0.Utils
+{
+    using System;
+    using System.Security.Cryptography;
+    using System.Text;
+
+    public static class RecoveryCodeGenerator
+    {
+        // Ambiguity-free alphabet: no 0/O, 1/I/L, U/V pairs.
+        // 32 chars = 5 bits per char.
+        private const string Alphabet = "ABCDEFGHJKMNPQRSTWXYZ23456789";
+
+        // Generates a code of the form "tip-XXXX-XXXX-XXXX" (3 groups of 4).
+        // ~60 bits of entropy — plenty for a friend-pool reset secret.
+        public static string Generate()
+        {
+            const int groups = 3;
+            const int groupLen = 4;
+            const int totalChars = groups * groupLen;
+
+            var bytes = new byte[totalChars];
+            using (var rng = RandomNumberGenerator.Create())
+            {
+                rng.GetBytes(bytes);
+            }
+
+            var sb = new StringBuilder("tip-");
+            for (int i = 0; i < totalChars; i++)
+            {
+                sb.Append(Alphabet[bytes[i] % Alphabet.Length]);
+                if ((i + 1) % groupLen == 0 && i != totalChars - 1)
+                {
+                    sb.Append('-');
+                }
+            }
+            return sb.ToString();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds a self-service password reset path that doesn't require sending email from the app. Each user has a plaintext recovery code; the admin can read it in the admin UI and email it out-of-band when a user asks.

## Why plaintext

We don't have an email sending pipeline and users will forget their codes. The admin needs to be able to look them up and re-share. Documented in the model as an accepted tradeoff for a private friend pool of ~40 people.

## Backend

- `ApplicationUser.RecoveryCode` (nvarchar, nullable). Migration `AddRecoveryCodeToUser` applied.
- `Utils.RecoveryCodeGenerator`: cryptographically random `tip-XXXX-XXXX-XXXX` (~60 bits, no ambiguous chars like 0/O, 1/I/L, U/V).
- `POST /api/auth/recovery/reset` (anonymous). Verifies identifier + code, replaces password via `RemovePasswordAsync` + `AddPasswordAsync`, signs the user in. Recovery code stays unchanged so admin can keep helping the same user. Identifier resolution is resilient: `FindByEmailAsync` → `FindByNameAsync` → case-insensitive scan against raw `Email`/`UserName` (handles legacy accounts with stale `NormalizedEmail`).
- `Register` now generates a code at sign-up and returns it in the response so the new user can save it immediately.
- `AdminController`:
  - `GET /api/admin/users` includes per-user `recoveryCode`.
  - `POST /api/admin/recovery-codes/missing`: bulk-generate for any user without a code, returns plaintext map `[{userName, email, recoveryCode}]` for one-time distribution.
  - `POST /api/admin/{userId}/recovery-code`: regenerate a single user's code.

## Frontend

- New `/authentication/recovery` route + flow in `Login.js`. Form: email/username + recovery code + new password → on success, signed in and redirected home.
- Login page: link "Zapomněl jsi heslo? Použij záchranný kód".
- Register: after successful signup, shows the recovery code on a "save this" screen with a copy button and an explicit acknowledgement gate before redirecting.
- Admin user list:
  - Per-row monospace recovery code (click to copy) + a regenerate button (confirmation modal).
  - Yellow "X uživatelů bez záchranného kódu" bar at the top of the list when any users lack a code. Click "Vygenerovat chybějící kódy" → backend generates them → result is rendered inline as a copyable TSV (username, email, code) for emailing.

## Test plan

- [ ] After deploy, hit admin → bulk-generate codes for all existing users → copy TSV → email each user their code.
- [ ] Existing user, knows their code: `/authentication/recovery` → enter email + code + new password → lands on home, logged in.
- [ ] Same flow with username instead of email: works (FindByName fallback).
- [ ] Recovery code stays valid after reset (admin can keep referring to the same one).
- [ ] Register a new account: shown the recovery code → save → home page works.
- [ ] Admin "Regenerate code" for a single user: confirm modal → code updates inline.
- [ ] Wrong code or wrong identifier returns "Neplatné údaje" (generic, no account-existence oracle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)