### PR TITLE
Fix Dixit stats KPI and add Home nav link

### DIFF
--- a/ClientApp/src/components/NavMenu.tsx
+++ b/ClientApp/src/components/NavMenu.tsx
@@ -72,6 +72,9 @@ export class NavMenu extends React.Component<INavMenuProps, INavMenuState> {
             <div className="d-none d-sm-flex flex-sm-row-reverse flex-grow-1">
               <ul className="navbar-nav flex-grow">
                 <NavItem>
+                  <NavLink tag={Link} to="/">Domů</NavLink>
+                </NavItem>
+                <NavItem>
                   <NavLink tag={Link} to="/tips">Sázky</NavLink>
                 </NavItem>
                 <NavItem>
@@ -99,6 +102,7 @@ export class NavMenu extends React.Component<INavMenuProps, INavMenuState> {
         <nav className={`drawer ${this.state.drawerOpen ? 'open' : ''}`}>
           <Link to="/" className="drawer-brand" onClick={this.closeDrawer}>Tipovačka MS 2026</Link>
           <ul className="drawer-nav">
+            <li><Link to="/" onClick={this.closeDrawer}>Domů</Link></li>
             <li><Link to="/tips" onClick={this.closeDrawer}>Sázky</Link></li>
             <li><Link to="/rules" onClick={this.closeDrawer}>Pravidla</Link></li>
             <li><Link to="/stats" onClick={this.closeDrawer}>Statistiky</Link></li>

--- a/ClientApp/src/components/Stats/StatsPage.tsx
+++ b/ClientApp/src/components/Stats/StatsPage.tsx
@@ -76,11 +76,11 @@ export class StatsPage extends React.Component<{}, StatsPageState> {
                             ? <p className="stats-empty">Zatím žádné dixity</p>
                             : <table className="stats-table">
                                 <thead>
-                                    <tr><th>Hráč</th><th>Počet</th></tr>
+                                    <tr><th>Hráč</th><th>Počet</th><th>Body</th></tr>
                                 </thead>
                                 <tbody>
                                     {stats.dixitLegends.map((d, i) => (
-                                        <tr key={i}><td>{d.userName}</td><td className="stats-value">{d.count}</td></tr>
+                                        <tr key={i}><td>{d.userName}</td><td className="stats-value">{d.count}</td><td className="stats-value">{d.points}</td></tr>
                                     ))}
                                 </tbody>
                             </table>

--- a/ClientApp/src/typings/index.ts
+++ b/ClientApp/src/typings/index.ts
@@ -194,7 +194,7 @@ export interface StatsResponse {
     rankingOverTime: RankingOverTimeEntry[];
     matchNoOneGuessed: MatchStatEntry[];
     exactScoreHeroes: PlayerCountStat[];
-    dixitLegends: PlayerCountStat[];
+    dixitLegends: DixitLegendStat[];
     biggestUpsets: MatchPercentageStat[];
     mostPredictableMatches: MatchPercentageStat[];
     jokerEfficiency: JokerEfficiencyStat[];
@@ -247,6 +247,12 @@ export interface MatchStatEntry {
 export interface PlayerCountStat {
     userName: string;
     count: number;
+}
+
+export interface DixitLegendStat {
+    userName: string;
+    count: number;
+    points: number;
 }
 
 export interface MatchPercentageStat {

--- a/Controllers/StatsController.cs
+++ b/Controllers/StatsController.cs
@@ -235,10 +235,10 @@ namespace TipTournament2._0.Controllers
         private object ComputeDixitLegends(List<MatchBet> betsOnEnded)
         {
             return betsOnEnded
-                .Where(b => b.DixitBonus == 3)
+                .Where(b => b.DixitBonus > 0)
                 .GroupBy(b => b.User.UserName)
-                .Select(g => new { UserName = g.Key, Count = g.Count() })
-                .OrderByDescending(x => x.Count)
+                .Select(g => new { UserName = g.Key, Count = g.Count(), Points = g.Sum(b => b.DixitBonus) })
+                .OrderByDescending(x => x.Points)
                 .ToList();
         }
 


### PR DESCRIPTION
## Summary
- Fix Dixit legends KPI: previously filtered `DixitBonus == 3` (only the rare lone-correct-guesser case), now includes any non-zero Dixit bonus
- Show both count and total Dixit points in the KPI table, ordered by points descending
- Add **Domů** link to the navbar (desktop) and mobile drawer pointing to `/`

## Test plan
- [ ] Stats page: Dixit legendy table populates for users with 1/2/3-point Dixit bonuses, sorted by total points
- [ ] Stats page: Both "Počet" and "Body" columns render correctly
- [ ] Navbar shows "Domů" link on desktop and in the mobile drawer
- [ ] Clicking "Domů" navigates to `/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)