### PR TITLE
Fix final additional-delta scoring and add tournament celebration popup

### DIFF
--- a/Calculator/BetResultMaker.cs
+++ b/Calculator/BetResultMaker.cs
@@ -46,8 +46,17 @@
             var finalBetsList = new List<DeltaBet>();
             foreach (var bet in bets)
             {
-                var additionalHomeTeamCorrect = bet.HomeTeamBetId == match.HomeId || bet.HomeTeamBetId == match.AwayId;
-                var addtionalAwayTeamCorrect = bet.AwayTeamBetId == match.AwayId || bet.AwayTeamBetId == match.HomeId;
+                // Additional points reward a predicted team that reached this match through a different part
+                // of the bracket. When the bet belongs to this same match (the final), a team that landed in
+                // the exact slot it was predicted for went the correct way and is already scored by the
+                // regular evaluation, so it must not earn additional points.
+                var isSameMatch = bet.MatchId == match.Id;
+
+                var homeTeamReached = bet.HomeTeamBetId == match.HomeId || bet.HomeTeamBetId == match.AwayId;
+                var awayTeamReached = bet.AwayTeamBetId == match.AwayId || bet.AwayTeamBetId == match.HomeId;
+
+                var additionalHomeTeamCorrect = homeTeamReached && !(isSameMatch && bet.HomeTeamBetId == match.HomeId);
+                var addtionalAwayTeamCorrect = awayTeamReached && !(isSameMatch && bet.AwayTeamBetId == match.AwayId);
 
                 if (additionalHomeTeamCorrect || addtionalAwayTeamCorrect)
                 {

--- a/ClientApp/src/components/MainPage/MainPage.tsx
+++ b/ClientApp/src/components/MainPage/MainPage.tsx
@@ -3,11 +3,18 @@ import authService from './../api-authorization/AuthorizeService';
 import { MainInnerPage } from './MainPageInner';
 import { Ranking } from './Ranking';
 import './../../custom.css';
-import { TournamentStage } from '../../typings';
+import { TournamentStage, User } from '../../typings';
+import { getApi } from '../api/ApiFactory';
+import { TournamentCelebrationModal } from './TournamentCelebrationModal';
+
+const CELEBRATION_DISMISSED_KEY = 'tt_celebration_dismissed_v1';
 
 interface MainPageState {
     currentUser: string;
     activeStage: TournamentStage;
+    tournamentFinished: boolean;
+    celebrationUsers: User[];
+    showCelebration: boolean;
 }
 
 interface MainPageProps { }
@@ -18,7 +25,10 @@ export class MainPage extends React.Component<MainPageProps, MainPageState> {
         super(props);
         this.state = {
             currentUser: "",
-            activeStage: this.getActiveStage()
+            activeStage: this.getActiveStage(),
+            tournamentFinished: false,
+            celebrationUsers: [],
+            showCelebration: false
         };
     }
 
@@ -37,13 +47,71 @@ export class MainPage extends React.Component<MainPageProps, MainPageState> {
                         <Ranking currentUser={this.state.currentUser} />
                     </div>
                 </div>
+
+                {this.state.tournamentFinished && !this.state.showCelebration && (
+                    <button
+                        className="celebration-fab"
+                        onClick={this.openCelebration}
+                        title="Zobrazit konečné pořadí"
+                        aria-label="Zobrazit konečné pořadí"
+                    >
+                        🏆
+                    </button>
+                )}
+
+                {this.state.showCelebration && (
+                    <TournamentCelebrationModal
+                        users={this.state.celebrationUsers}
+                        currentUserId={this.state.currentUser}
+                        onClose={this.dismissCelebration}
+                    />
+                )}
             </div>
         );
     }
 
     private async getData() {
         const currentUser = await authService.getUser();
-        this.setState({ currentUser: currentUser["sub"] });
+        this.setState({ currentUser: currentUser ? currentUser["sub"] : "" });
+
+        try {
+            const [matches, users] = await Promise.all([
+                getApi().getAllMatches(),
+                getApi().getUsers(true)
+            ]);
+
+            const finished = matches.some(m => m.stage === TournamentStage.Final && m.ended);
+            const dismissed = this.isCelebrationDismissed();
+
+            this.setState({
+                tournamentFinished: finished,
+                celebrationUsers: users,
+                showCelebration: finished && !dismissed
+            });
+        } catch {
+            /* the celebration is non-critical — ignore load failures */
+        }
+    }
+
+    private openCelebration = () => {
+        this.setState({ showCelebration: true });
+    }
+
+    private dismissCelebration = () => {
+        try {
+            window.localStorage.setItem(CELEBRATION_DISMISSED_KEY, 'true');
+        } catch {
+            /* localStorage may be unavailable — ignore */
+        }
+        this.setState({ showCelebration: false });
+    }
+
+    private isCelebrationDismissed(): boolean {
+        try {
+            return window.localStorage.getItem(CELEBRATION_DISMISSED_KEY) === 'true';
+        } catch {
+            return false;
+        }
     }
 
     private getActiveStage(): TournamentStage {

--- a/ClientApp/src/components/MainPage/TournamentCelebrationModal.tsx
+++ b/ClientApp/src/components/MainPage/TournamentCelebrationModal.tsx
@@ -1,0 +1,129 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { User } from '../../typings/index';
+import './../../custom.css';
+
+interface TournamentCelebrationModalProps {
+    users: User[];
+    currentUserId: string;
+    onClose: () => void;
+}
+
+const STAR_COUNT = 28;
+
+const AI_PLAYER_TOKENS = ['chatgpt', 'copilot', 'claude', 'gemin'];
+
+interface RankedUser {
+    user: User;
+    place: number;
+}
+
+export class TournamentCelebrationModal extends React.Component<TournamentCelebrationModalProps> {
+
+    public render() {
+        const humans = this.props.users.filter(u => !this.isAiPlayer(u.userName));
+        const ranked = this.rankUsers(humans);
+        const podium = ranked.slice(0, 3);
+        const rest = ranked.slice(3);
+
+        return ReactDOM.createPortal(
+            <div className="celebration-overlay" onClick={this.props.onClose}>
+                <div className="celebration-stars" aria-hidden="true">
+                    {Array.from({ length: STAR_COUNT }).map((_, i) => (
+                        <span key={i} className="celebration-star" style={this.getStarStyle(i)}>★</span>
+                    ))}
+                </div>
+
+                <div className="celebration-card" onClick={e => e.stopPropagation()}>
+                    <button className="celebration-close" onClick={this.props.onClose} aria-label="Zavřít">&times;</button>
+
+                    <div className="celebration-head">
+                        <div className="celebration-trophy">🏆</div>
+                        <h2 className="celebration-title">Turnaj skončil!</h2>
+                        <p className="celebration-subtitle">Konečné pořadí</p>
+                    </div>
+
+                    <div className="celebration-podium">
+                        {this.renderPodiumSpot(podium[1], 'left')}
+                        {this.renderPodiumSpot(podium[0], 'center')}
+                        {this.renderPodiumSpot(podium[2], 'right')}
+                    </div>
+
+                    {rest.length > 0 && (
+                        <div className="celebration-list">
+                            {rest.map(entry => (
+                                <div
+                                    key={entry.user.userName}
+                                    className={`celebration-row ${entry.user.id === this.props.currentUserId ? 'celebration-row-current' : ''}`}
+                                >
+                                    <span className="celebration-rank">{entry.place}.</span>
+                                    <span className="celebration-name">{entry.user.userName}</span>
+                                    <span className="celebration-points">{entry.user.totalPoints} b</span>
+                                </div>
+                            ))}
+                        </div>
+                    )}
+                </div>
+            </div>,
+            document.body
+        );
+    }
+
+    private renderPodiumSpot(entry: RankedUser | undefined, position: 'left' | 'center' | 'right') {
+        if (!entry) {
+            return <div className={`celebration-spot celebration-spot--${position} celebration-spot-empty`} />;
+        }
+
+        const place = entry.place;
+        const medal = place === 1 ? '🥇' : place === 2 ? '🥈' : '🥉';
+        const isCurrent = entry.user.id === this.props.currentUserId;
+
+        return (
+            <div className={`celebration-spot celebration-spot--${position} celebration-spot--place${place} ${isCurrent ? 'celebration-spot-current' : ''}`}>
+                <div className="celebration-medal">{medal}</div>
+                <div className="celebration-spot-name" title={entry.user.userName}>{entry.user.userName}</div>
+                <div className="celebration-spot-points">{entry.user.totalPoints} b</div>
+                <div className="celebration-pedestal">{place}</div>
+            </div>
+        );
+    }
+
+    private rankUsers(users: User[]): RankedUser[] {
+        const sorted = [...users].sort((a, b) => b.totalPoints - a.totalPoints);
+
+        let previousPoints: number | null = null;
+        let previousPlace = 0;
+
+        return sorted.map((user, index) => {
+            const place = previousPoints !== null && user.totalPoints === previousPoints
+                ? previousPlace
+                : index + 1;
+            previousPoints = user.totalPoints;
+            previousPlace = place;
+            return { user, place };
+        });
+    }
+
+    private isAiPlayer(userName: string): boolean {
+        const normalized = userName.trim().toLowerCase();
+        return AI_PLAYER_TOKENS.some(token => normalized.includes(token));
+    }
+
+    private getStarStyle(i: number): React.CSSProperties {
+        const left = (i * 53) % 100;
+        const drift = (i % 2 === 0 ? 1 : -1) * (12 + (i % 5) * 8);
+        const duration = 4 + (i % 6);
+        const delay = -((i * 7) % 60) / 10;
+        const size = 10 + (i % 5) * 6;
+
+        const style: { [key: string]: string } = {
+            left: `${left}%`,
+            fontSize: `${size}px`,
+            animationDuration: `${duration}s`,
+            animationDelay: `${delay}s`,
+            '--drift': `${drift}px`,
+        };
+
+        return style as React.CSSProperties;
+    }
+}

--- a/ClientApp/src/custom.css
+++ b/ClientApp/src/custom.css
@@ -2729,3 +2729,310 @@ select option {
         min-width: 2.5rem;
     }
 }
+
+/* ===== Tournament Celebration Modal ===== */
+.celebration-overlay {
+    position: fixed;
+    inset: 0;
+    background: radial-gradient(ellipse at center, rgba(20, 30, 55, 0.75) 0%, rgba(5, 8, 18, 0.9) 100%);
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+    z-index: 1200;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: var(--space-md);
+    overflow: hidden;
+    animation: fadeIn 0.35s ease;
+}
+
+.celebration-stars {
+    position: absolute;
+    inset: 0;
+    overflow: hidden;
+    pointer-events: none;
+    z-index: 0;
+}
+
+.celebration-star {
+    position: absolute;
+    top: 0;
+    color: #ffd700;
+    text-shadow: 0 0 8px rgba(255, 215, 0, 0.9), 0 0 14px rgba(255, 200, 0, 0.5);
+    animation-name: celebration-star-fly;
+    animation-timing-function: linear;
+    animation-iteration-count: infinite;
+    will-change: transform, opacity;
+}
+
+@keyframes celebration-star-fly {
+    0%   { transform: translateY(112vh) translateX(0) rotate(0deg) scale(0.6); opacity: 0; }
+    12%  { opacity: 1; }
+    50%  { transform: translateY(45vh) translateX(var(--drift, 15px)) rotate(200deg) scale(1); opacity: 1; }
+    88%  { opacity: 1; }
+    100% { transform: translateY(-15vh) translateX(0) rotate(360deg) scale(0.6); opacity: 0; }
+}
+
+.celebration-card {
+    position: relative;
+    z-index: 1;
+    width: 100%;
+    max-width: 560px;
+    max-height: 88vh;
+    overflow-y: auto;
+    background: rgba(18, 26, 45, 0.9);
+    backdrop-filter: blur(24px);
+    -webkit-backdrop-filter: blur(24px);
+    border: 1px solid rgba(255, 215, 0, 0.35);
+    border-radius: var(--radius-lg);
+    box-shadow: 0 12px 60px rgba(0, 0, 0, 0.55), 0 0 40px rgba(255, 200, 0, 0.15);
+    padding: var(--space-xl) var(--space-lg) var(--space-lg);
+    animation: celebration-pop 0.5s cubic-bezier(0.18, 0.89, 0.32, 1.28);
+}
+
+.celebration-close {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.85rem;
+    background: none;
+    border: none;
+    font-size: 1.6rem;
+    color: var(--text-muted);
+    cursor: pointer;
+    line-height: 1;
+    z-index: 2;
+}
+
+.celebration-close:hover {
+    color: var(--text);
+}
+
+.celebration-head {
+    text-align: center;
+    margin-bottom: var(--space-lg);
+}
+
+.celebration-trophy {
+    font-size: 3.25rem;
+    line-height: 1;
+    filter: drop-shadow(0 0 14px rgba(255, 200, 0, 0.6));
+    animation: celebration-trophy-bounce 2.2s ease-in-out infinite;
+}
+
+.celebration-title {
+    margin: var(--space-sm) 0 0;
+    font-size: var(--font-2xl);
+    font-weight: 800;
+    letter-spacing: 0.5px;
+    background: linear-gradient(90deg, #fff6c2, #ffd700, #ffb347, #ffd700, #fff6c2);
+    background-size: 200% auto;
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+    animation: shimmer 4s linear infinite;
+}
+
+.celebration-subtitle {
+    margin: 0.15rem 0 0;
+    color: var(--text-secondary);
+    font-size: var(--font-sm);
+    text-transform: uppercase;
+    letter-spacing: 2px;
+}
+
+.celebration-podium {
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    gap: var(--space-sm);
+    margin-bottom: var(--space-lg);
+}
+
+.celebration-spot {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    flex: 1 1 0;
+    min-width: 0;
+    max-width: 33%;
+    text-align: center;
+}
+
+.celebration-spot-empty {
+    visibility: hidden;
+}
+
+.celebration-medal {
+    line-height: 1;
+    filter: drop-shadow(0 2px 6px rgba(0, 0, 0, 0.4));
+}
+
+.celebration-spot-name {
+    margin-top: 0.25rem;
+    font-weight: 700;
+    color: var(--text);
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.celebration-spot-points {
+    color: var(--text-secondary);
+    font-weight: 600;
+    margin-bottom: 0.4rem;
+}
+
+.celebration-pedestal {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 800;
+    color: rgba(0, 0, 0, 0.55);
+    border-radius: var(--radius-sm) var(--radius-sm) 0 0;
+    box-shadow: inset 0 2px 8px rgba(255, 255, 255, 0.4);
+}
+
+/* podium column ordering (1st place centered) */
+.celebration-spot--center { order: 2; }
+.celebration-spot--left { order: 1; }
+.celebration-spot--right { order: 3; }
+
+/* place-based appearance — gold / silver / bronze (shared by tied players) */
+.celebration-spot--place1 .celebration-medal { font-size: 3rem; }
+.celebration-spot--place1 .celebration-spot-name { font-size: var(--font-lg); }
+.celebration-spot--place1 .celebration-spot-points { font-size: var(--font-md); color: #ffe27a; }
+.celebration-spot--place1 .celebration-pedestal {
+    height: 92px;
+    font-size: 2rem;
+    background: linear-gradient(180deg, #ffe27a, #ffc107 60%, #e0a000);
+}
+
+.celebration-spot--place2 .celebration-medal { font-size: 2.2rem; }
+.celebration-spot--place2 .celebration-spot-name { font-size: var(--font-base); }
+.celebration-spot--place2 .celebration-pedestal {
+    height: 66px;
+    font-size: 1.5rem;
+    background: linear-gradient(180deg, #eef2f7, #c0c8d4 60%, #98a2b3);
+}
+
+.celebration-spot--place3 .celebration-medal { font-size: 2.2rem; }
+.celebration-spot--place3 .celebration-spot-name { font-size: var(--font-base); }
+.celebration-spot--place3 .celebration-pedestal {
+    height: 46px;
+    font-size: 1.35rem;
+    background: linear-gradient(180deg, #e8b587, #cd7f32 60%, #a05a1f);
+}
+
+.celebration-spot-current .celebration-spot-name {
+    color: var(--primary-light);
+}
+
+.celebration-spot-current .celebration-medal {
+    animation: celebration-trophy-bounce 1.6s ease-in-out infinite;
+}
+
+.celebration-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    max-height: 32vh;
+    overflow-y: auto;
+    padding-right: 0.25rem;
+}
+
+.celebration-row {
+    display: flex;
+    align-items: center;
+    gap: var(--space-sm);
+    padding: 0.5rem 0.85rem;
+    background: rgba(255, 255, 255, 0.05);
+    border-radius: var(--radius-sm);
+}
+
+.celebration-row-current {
+    background: var(--primary-bg);
+    box-shadow: inset 0 0 0 1px rgba(99, 179, 237, 0.5);
+}
+
+.celebration-rank {
+    width: 2rem;
+    color: var(--text-muted);
+    font-weight: 700;
+    flex-shrink: 0;
+}
+
+.celebration-name {
+    flex: 1;
+    font-weight: 600;
+    color: var(--text);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.celebration-points {
+    font-weight: 700;
+    color: var(--text-secondary);
+    flex-shrink: 0;
+}
+
+.celebration-row-current .celebration-name {
+    color: var(--primary-light);
+}
+
+/* Floating re-open button */
+.celebration-fab {
+    position: fixed;
+    bottom: 1.5rem;
+    right: 1.5rem;
+    z-index: 1100;
+    width: 3.5rem;
+    height: 3.5rem;
+    border-radius: 50%;
+    border: none;
+    font-size: 1.6rem;
+    cursor: pointer;
+    background: linear-gradient(145deg, #ffe27a, #ffc107 55%, #e0a000);
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4), 0 0 18px rgba(255, 200, 0, 0.4);
+    animation: celebration-fab-pulse 2.4s ease-in-out infinite;
+    transition: transform var(--transition-fast);
+}
+
+.celebration-fab:hover {
+    transform: scale(1.1);
+}
+
+@keyframes celebration-trophy-bounce {
+    0%, 100% { transform: translateY(0) rotate(-4deg); }
+    50%      { transform: translateY(-8px) rotate(4deg); }
+}
+
+@keyframes celebration-pop {
+    0%   { transform: scale(0.85); opacity: 0; }
+    100% { transform: scale(1); opacity: 1; }
+}
+
+@keyframes celebration-fab-pulse {
+    0%, 100% { box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4), 0 0 0 0 rgba(255, 200, 0, 0.5); }
+    50%      { box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4), 0 0 0 12px rgba(255, 200, 0, 0); }
+}
+
+@media (max-width: 480px) {
+    .celebration-card { padding: var(--space-lg) var(--space-md) var(--space-md); }
+    .celebration-trophy { font-size: 2.6rem; }
+    .celebration-spot--place1 .celebration-medal { font-size: 2.4rem; }
+    .celebration-spot--place1 .celebration-spot-name { font-size: var(--font-base); }
+    .celebration-spot--place2 .celebration-medal,
+    .celebration-spot--place3 .celebration-medal { font-size: 1.8rem; }
+    .celebration-fab { bottom: 1rem; right: 1rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .celebration-star { display: none; }
+    .celebration-trophy,
+    .celebration-title,
+    .celebration-fab,
+    .celebration-spot-current .celebration-medal { animation: none; }
+}

--- a/Scripts/fix-final-additional-points.sql
+++ b/Scripts/fix-final-additional-points.sql
@@ -1,0 +1,117 @@
+-- ============================================================
+-- Fix: remove wrongly-awarded "advanced through a different part
+-- of the bracket" (AdditionalResult) points from the FINAL.
+--
+-- Bug: for the final, additional points were credited even when the
+-- predicted finalist landed in the SAME slot it was predicted for
+-- (i.e. it went the correct way) - which is already scored by the
+-- regular evaluation. Only a *crossed* finalist should earn the
+-- additional points:
+--     home slot: predicted home team finished as the away finalist  (HomeTeamBetId = AwayId)
+--     away slot: predicted away team finished as the home finalist  (AwayTeamBetId = HomeId)
+--
+-- Per-bet points wrongly added (to remove):
+--     2 * (HomeTeamBetId = HomeId) + 2 * (AwayTeamBetId = AwayId)
+--
+-- Only Stage 5 (TournamentStage.Final) is affected; earlier knockout
+-- rounds evaluate the additional result against OTHER matches, so those
+-- points are legitimate and are intentionally left untouched.
+--
+-- Run inside the transaction, review the SELECTs, then COMMIT.
+-- ============================================================
+
+BEGIN TRANSACTION;
+
+DECLARE @FinalStage INT = 5;
+
+IF OBJECT_ID('tempdb..#FinalFix') IS NOT NULL DROP TABLE #FinalFix;
+
+-- Every final DeltaBet that currently carries an AdditionalResult,
+-- with the stored points, the corrected (crossed-only) values and the
+-- amount that must be deducted from the player.
+SELECT
+    db.Id            AS DeltaBetId,
+    db.UserId        AS UserId,
+    add_r.Id         AS AdditionalResultId,
+    add_r.Points     AS StoredAdditionalPoints,
+    CAST(CASE WHEN db.HomeTeamBetId = m.AwayId THEN 1 ELSE 0 END AS BIT) AS NewHomeCorrect,
+    CAST(CASE WHEN db.AwayTeamBetId = m.HomeId THEN 1 ELSE 0 END AS BIT) AS NewAwayCorrect,
+    (CASE WHEN db.HomeTeamBetId = m.AwayId THEN 2 ELSE 0 END
+   + CASE WHEN db.AwayTeamBetId = m.HomeId THEN 2 ELSE 0 END)            AS NewPoints,
+    (CASE WHEN db.HomeTeamBetId = m.HomeId THEN 2 ELSE 0 END
+   + CASE WHEN db.AwayTeamBetId = m.AwayId THEN 2 ELSE 0 END)            AS Deduction
+INTO #FinalFix
+FROM dbo.DeltaBets db
+JOIN dbo.Matches m             ON m.Id = db.MatchId
+JOIN dbo.DeltaBetResults r     ON r.Id = db.ResultId
+JOIN dbo.DeltaBetResults add_r ON add_r.Id = r.AdditionalResultId
+WHERE m.Stage = @FinalStage;
+
+-- ---- (a) anomaly check: stored points should equal Deduction + NewPoints.
+--         Any rows here mean the stored additional points are not what the
+--         buggy code would have produced (e.g. the final was uploaded twice).
+--         Investigate before committing.
+SELECT 'ANOMALY - stored <> deduction + corrected' AS info, f.*
+FROM #FinalFix f
+WHERE f.StoredAdditionalPoints <> f.Deduction + f.NewPoints;
+
+-- ---- (b) preview the players who will lose points ----
+SELECT u.UserName, u.DeltaPoints, u.TotalPoints,
+       f.StoredAdditionalPoints, f.NewPoints, f.Deduction
+FROM #FinalFix f
+JOIN dbo.AspNetUsers u ON u.Id = f.UserId
+WHERE f.Deduction > 0
+ORDER BY f.Deduction DESC, u.UserName;
+
+-- ---- 1. deduct the wrongly-awarded points from each player ----
+;WITH PerUser AS (
+    SELECT UserId, SUM(Deduction) AS Ded
+    FROM #FinalFix
+    GROUP BY UserId
+)
+UPDATE u
+SET u.DeltaPoints = u.DeltaPoints - p.Ded,
+    u.TotalPoints = u.TotalPoints - p.Ded
+FROM dbo.AspNetUsers u
+JOIN PerUser p ON p.UserId = u.Id
+WHERE p.Ded > 0;
+
+-- ---- 2. correct the additional result structure (crossed-only) ----
+UPDATE add_r
+SET add_r.IsHomeTeamCorrect = f.NewHomeCorrect,
+    add_r.IsAwayTeamCorrect = f.NewAwayCorrect,
+    add_r.Points            = f.NewPoints
+FROM dbo.DeltaBetResults add_r
+JOIN #FinalFix f ON f.AdditionalResultId = add_r.Id
+WHERE add_r.Points            <> f.NewPoints
+   OR add_r.IsHomeTeamCorrect <> f.NewHomeCorrect
+   OR add_r.IsAwayTeamCorrect <> f.NewAwayCorrect;
+
+-- ---- 3. (OPTIONAL) drop additional results that are now empty ----
+--         The fixed code creates no AdditionalResult when nothing crossed.
+--         Leaving a 0-point row is harmless (badge hidden, adds 0), so this
+--         step is optional cleanup. Uncomment to remove the empty rows.
+-- UPDATE r
+-- SET r.AdditionalResultId = NULL
+-- FROM dbo.DeltaBetResults r
+-- JOIN #FinalFix f ON f.AdditionalResultId = r.AdditionalResultId
+-- WHERE f.NewPoints = 0;
+--
+-- DELETE add_r
+-- FROM dbo.DeltaBetResults add_r
+-- JOIN #FinalFix f ON f.AdditionalResultId = add_r.Id
+-- WHERE f.NewPoints = 0;
+
+-- ---- verify final state ----
+SELECT u.UserName, u.DeltaPoints, u.TotalPoints,
+       add_r.Points AS AdditionalPointsNow,
+       add_r.IsHomeTeamCorrect, add_r.IsAwayTeamCorrect
+FROM #FinalFix f
+JOIN dbo.AspNetUsers u         ON u.Id = f.UserId
+JOIN dbo.DeltaBetResults add_r ON add_r.Id = f.AdditionalResultId
+ORDER BY u.UserName;
+
+DROP TABLE #FinalFix;
+
+-- ROLLBACK;   -- default: abort. Review the SELECTs above first.
+-- COMMIT;     -- uncomment to apply

--- a/TipTournament2.0.Tests/Calculator/BetResultMakerTests.cs
+++ b/TipTournament2.0.Tests/Calculator/BetResultMakerTests.cs
@@ -256,12 +256,57 @@ namespace TipTournament2._0.Tests.Calculator
         }
 
         [Fact]
-        public void UpdateAdditionalDeltaBetsResult_OnlyHomeMatchesHome_Returns2Points()
+        public void UpdateAdditionalDeltaBetsResult_DifferentMatchHomeTeamReached_Returns2Points()
         {
-            var match = new Match { HomeId = "teamA", AwayId = "teamB" };
+            var match = new Match { Id = "match_2", HomeId = "teamA", AwayId = "teamB" };
             var bets = new List<DeltaBet>
             {
-                new DeltaBet { HomeTeamBetId = "teamA", AwayTeamBetId = "teamC", Result = null }
+                new DeltaBet { MatchId = "match_1", HomeTeamBetId = "teamA", AwayTeamBetId = "teamC", Result = null }
+            };
+
+            var updated = this.sut.UpdateAdditionalDeltaBetsResult(bets, match);
+
+            Assert.Single(updated);
+            Assert.Equal(2, updated[0].Result.AdditionalResult.Points);
+            Assert.True(updated[0].Result.AdditionalResult.IsHomeTeamCorrect);
+            Assert.False(updated[0].Result.AdditionalResult.IsAwayTeamCorrect);
+        }
+
+        [Fact]
+        public void UpdateAdditionalDeltaBetsResult_SameMatchCorrectSlots_ExcludedFromResult()
+        {
+            var match = new Match { Id = "match_final", HomeId = "teamA", AwayId = "teamB" };
+            var bets = new List<DeltaBet>
+            {
+                new DeltaBet { MatchId = "match_final", HomeTeamBetId = "teamA", AwayTeamBetId = "teamB", Result = null }
+            };
+
+            var updated = this.sut.UpdateAdditionalDeltaBetsResult(bets, match);
+
+            Assert.Empty(updated);
+        }
+
+        [Fact]
+        public void UpdateAdditionalDeltaBetsResult_SameMatchHomeCorrectSlotAwayMissing_ExcludedFromResult()
+        {
+            var match = new Match { Id = "match_final", HomeId = "teamA", AwayId = "teamB" };
+            var bets = new List<DeltaBet>
+            {
+                new DeltaBet { MatchId = "match_final", HomeTeamBetId = "teamA", AwayTeamBetId = "teamC", Result = null }
+            };
+
+            var updated = this.sut.UpdateAdditionalDeltaBetsResult(bets, match);
+
+            Assert.Empty(updated);
+        }
+
+        [Fact]
+        public void UpdateAdditionalDeltaBetsResult_SameMatchHomeCrossedToAway_Returns2Points()
+        {
+            var match = new Match { Id = "match_final", HomeId = "teamA", AwayId = "teamB" };
+            var bets = new List<DeltaBet>
+            {
+                new DeltaBet { MatchId = "match_final", HomeTeamBetId = "teamB", AwayTeamBetId = "teamC", Result = null }
             };
 
             var updated = this.sut.UpdateAdditionalDeltaBetsResult(bets, match);
@@ -289,10 +334,10 @@ namespace TipTournament2._0.Tests.Calculator
         [Fact]
         public void UpdateAdditionalDeltaBetsResult_InitializesNestedResults()
         {
-            var match = new Match { HomeId = "teamA", AwayId = "teamB" };
+            var match = new Match { Id = "match_final", HomeId = "teamA", AwayId = "teamB" };
             var bets = new List<DeltaBet>
             {
-                new DeltaBet { HomeTeamBetId = "teamA", AwayTeamBetId = "teamB", Result = null }
+                new DeltaBet { MatchId = "match_final", HomeTeamBetId = "teamB", AwayTeamBetId = "teamA", Result = null }
             };
 
             var updated = this.sut.UpdateAdditionalDeltaBetsResult(bets, match);


### PR DESCRIPTION
## Summary

### Bug fix: final additional-delta scoring
The final's additional-delta evaluation was awarding bonus points (labelled "points for advancing through a different part of the bracket") even when a team reached the final via the **correct** bracket slot. Only genuine cross-bracket progress should score. Fixed in `BetResultMaker` by excluding the exact-correct same-match slot; non-final stages are unchanged. Tests updated/added (176/176 pass).

### Data correction
Added `Scripts/fix-final-additional-points.sql` — a transaction-wrapped script that retroactively deducts the wrongly-awarded points and rewrites the stored additional-result rows for the final (Stage=5 only). Includes an anomaly check and an affected-players preview; ends on ROLLBACK by default.

### New: tournament celebration popup
When the tournament finishes (final match ended), a celebration modal shows the final ranking:
- Top-3 podium (gold/silver/bronze) plus the full ranked list
- Flying-stars animation, current-user highlight, reduced-motion support
- **Ties share a place** (standard competition ranking: 1, 2, 2, 4)
- **AI players excluded** (ChatGPT, Copilot, Claude, Gemini)
- Auto-opens once per browser (localStorage), with a floating trophy button to reopen

## Test plan
- `dotnet test` — 176/176 pass
- `npm run build` (react-scripts) — succeeds, no new warnings
